### PR TITLE
minor improvement for bootstrapping

### DIFF
--- a/algebra/src/polynomial/ntt_polynomial.rs
+++ b/algebra/src/polynomial/ntt_polynomial.rs
@@ -532,7 +532,7 @@ pub fn ntt_mul_assign_ref<'a, F: NTTField + 'a, I: IntoIterator<Item = &'a F>>(
 }
 
 /// Performs enrty-wise add_mul operation.
-/// 
+///
 /// Treats three iterators as [`NTTPolynomial<F>`]'s iterators,
 /// then multiply enrty-wise over last two iterators, and add back to the first
 /// iterator.
@@ -555,7 +555,7 @@ pub fn ntt_add_mul_assign<
 }
 
 /// Performs enrty-wise add_mul operation.
-/// 
+///
 /// Treats three iterators as [`NTTPolynomial<F>`]'s iterators,
 /// then multiply enrty-wise over last two iterators, and add back to the first
 /// iterator.

--- a/boolean_fhe/src/bootstrapping_key/binary.rs
+++ b/boolean_fhe/src/bootstrapping_key/binary.rs
@@ -29,12 +29,11 @@ impl<F: NTTField> BinaryBootstrappingKey<F> {
         let polynomial_space = &mut PolynomialSpace::new(rlwe_dimension);
         let ntt_rlwe_space = &mut NTTRLWESpace::new(rlwe_dimension);
         let acc_mul_rgsw = &mut RLWESpace::new(rlwe_dimension);
-        let median = &mut RLWESpace::new(rlwe_dimension);
 
         self.key
             .iter()
             .zip(lwe_a)
-            .fold(init_acc, |acc, (s_i, &a_i)| {
+            .fold(init_acc, |mut acc, (s_i, &a_i)| {
                 // acc_mul_rgsw = ACC * RGSW(s_i)
                 acc.mul_small_ntt_rgsw_inplace(
                     s_i,
@@ -43,15 +42,17 @@ impl<F: NTTField> BinaryBootstrappingKey<F> {
                     ntt_rlwe_space,
                     acc_mul_rgsw,
                 );
-                // median = (Y^{-a_i} - 1) * ACC * RGSW(s_i)
-                acc_mul_rgsw.mul_monic_monomial_sub_one_inplace(
+                // ACC = ACC - ACC * RGSW(s_i)
+                acc.sub_assign_element_wise(acc_mul_rgsw);
+                // ACC = ACC - ACC * RGSW(s_i) + Y^{-a_i} * ACC * RGSW(s_i)
+                //     = ACC + (Y^{-a_i} - 1) * ACC * RGSW(s_i)
+                acc.add_assign_rhs_mul_monic_monomial(
+                    acc_mul_rgsw,
                     rlwe_dimension,
                     twice_rlwe_dimension_div_lwe_modulus,
                     -a_i,
-                    median,
                 );
-                // ACC = ACC + (Y^{-a_i} - 1) * ACC * RGSW(s_i)
-                acc.add_element_wise(median)
+                acc
             })
     }
 }

--- a/lattice/benches/rlwe_bench.rs
+++ b/lattice/benches/rlwe_bench.rs
@@ -47,11 +47,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("RLWE add inplace element wise", |b| {
-        b.iter(|| black_box(&mut c0).add_inplace_element_wise(black_box(&c1)))
+        b.iter(|| black_box(&mut c0).add_assign_element_wise(black_box(&c1)))
     });
 
     group.bench_function("RLWE sub inplace element wise", |b| {
-        b.iter(|| black_box(&mut c0).sub_inplace_element_wise(black_box(&c1)))
+        b.iter(|| black_box(&mut c0).sub_assign_element_wise(black_box(&c1)))
     });
 
     group.finish()


### PR DESCRIPTION
Modify the bootstrapping procedure from `ACC * RGSW(s_i)` to `ACC + (Y^{-a_i} - 1) * ACC * RGSW(s_i)`. Reduce one allocation of `RLWE<F>`.