### PR TITLE
set parameters with 128-bit security

### DIFF
--- a/boolean_fhe/benches/nand_bench.rs
+++ b/boolean_fhe/benches/nand_bench.rs
@@ -1,4 +1,4 @@
-use boolean_fhe::{EvaluationKey, SecretKeyPack, DEFAULT_100_BITS_PARAMERTERS};
+use boolean_fhe::{EvaluationKey, SecretKeyPack, DEFAULT_TERNARY_128_BITS_PARAMERTERS};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
@@ -7,7 +7,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
     // set parameter
-    let default_parameters = DEFAULT_100_BITS_PARAMERTERS.clone();
+    let default_parameters = DEFAULT_TERNARY_128_BITS_PARAMERTERS.clone();
 
     // generate keys
     let skp = SecretKeyPack::new(default_parameters);

--- a/boolean_fhe/examples/fhe.rs
+++ b/boolean_fhe/examples/fhe.rs
@@ -1,4 +1,4 @@
-use boolean_fhe::{EvaluationKey, LWEType, SecretKeyPack, DEFAULT_100_BITS_PARAMERTERS};
+use boolean_fhe::{EvaluationKey, LWEType, SecretKeyPack, DEFAULT_TERNARY_128_BITS_PARAMERTERS};
 use rand::Rng;
 
 fn main() {
@@ -6,7 +6,7 @@ fn main() {
     let mut rng = rand::thread_rng();
 
     // set parameter
-    let params = DEFAULT_100_BITS_PARAMERTERS.clone();
+    let params = DEFAULT_TERNARY_128_BITS_PARAMERTERS.clone();
 
     let noise_max = (params.lwe_modulus_f64() / 16.0) as LWEType;
 

--- a/boolean_fhe/src/evaluation_key.rs
+++ b/boolean_fhe/src/evaluation_key.rs
@@ -146,7 +146,7 @@ fn test_init_nand_acc() {
     use algebra::reduce::{NegReduce, SubReduce};
     use algebra::Field;
 
-    use crate::DefaultField100;
+    use crate::DefaultFieldTernary128;
 
     const N: usize = 64;
     let q = 16u16;
@@ -155,7 +155,7 @@ fn test_init_nand_acc() {
     let l = (q >> 3) * 3;
     let r = (q >> 3) * 7;
     for b in 0..q {
-        let acc = init_nand_acc::<DefaultField100>(b, N, ratio);
+        let acc = init_nand_acc::<DefaultFieldTernary128>(b, N, ratio);
         for a in 0..q {
             let ra = a.neg_reduce(modulus) as usize * ratio;
             let m = if ra == 0 {
@@ -169,9 +169,9 @@ fn test_init_nand_acc() {
             };
 
             if (l..r).contains(&(b.sub_reduce(a, modulus))) {
-                assert_eq!(m, DefaultField100::NEG_Q_DIV_8, "b:{b} a:{a}");
+                assert_eq!(m, DefaultFieldTernary128::NEG_Q_DIV_8, "b:{b} a:{a}");
             } else {
-                assert_eq!(m, DefaultField100::Q_DIV_8, "b:{b} a:{a}");
+                assert_eq!(m, DefaultFieldTernary128::Q_DIV_8, "b:{b} a:{a}");
             }
         }
     }

--- a/boolean_fhe/src/lib.rs
+++ b/boolean_fhe/src/lib.rs
@@ -18,8 +18,8 @@ mod secret_key;
 pub use error::FHEError;
 
 pub use parameter::{
-    ConstParameters, DefaultField100, Parameters, ParametersBuilder,
-    CONST_DEFAULT_100_BITS_PARAMERTERS, DEFAULT_100_BITS_PARAMERTERS,
+    ConstParameters, DefaultFieldTernary128, Parameters, ParametersBuilder,
+    CONST_DEFAULT_TERNARY_128_BITS_PARAMERTERS, DEFAULT_TERNARY_128_BITS_PARAMERTERS,
 };
 
 pub use ciphertext::{LWECiphertext, NTTRLWECiphertext, RLWECiphertext};

--- a/boolean_fhe/src/parameter.rs
+++ b/boolean_fhe/src/parameter.rs
@@ -419,23 +419,25 @@ impl<F: NTTField> ParametersBuilder<F> {
 /// Default Field for Default Parameters
 #[derive(Field, Random, Prime, NTT)]
 #[modulus = 132120577]
-pub struct DefaultField100(u32);
+pub struct DefaultFieldTernary128(u32);
 
 /// Default Parameters
-pub const CONST_DEFAULT_100_BITS_PARAMERTERS: ConstParameters<u32> = ConstParameters::<u32> {
+pub const CONST_DEFAULT_TERNARY_128_BITS_PARAMERTERS: ConstParameters<u32> = ConstParameters::<u32> {
     lwe_dimension: 512,
-    lwe_modulus: 512,
+    lwe_modulus: 1024,
     lwe_noise_std_dev: 3.20,
     secret_key_type: SecretKeyType::Ternary,
     rlwe_dimension: 1024,
     rlwe_modulus: 132120577,
     rlwe_noise_std_dev: 3.20,
-    gadget_basis_bits: 6,
-    key_switching_basis_bits: 3,
-    key_switching_std_dev: (1u32 << 12) as f64,
+    gadget_basis_bits: 8,
+    key_switching_basis_bits: 4,
+    key_switching_std_dev: 3.2 * ((1 << 7) as f64),
 };
 
-/// Default 100bits security Parameters
-pub static DEFAULT_100_BITS_PARAMERTERS: Lazy<Parameters<DefaultField100>> = Lazy::new(|| {
-    <Parameters<DefaultField100>>::try_from(CONST_DEFAULT_100_BITS_PARAMERTERS).unwrap()
-});
+/// Default 128-bits security Parameters
+pub static DEFAULT_TERNARY_128_BITS_PARAMERTERS: Lazy<Parameters<DefaultFieldTernary128>> =
+    Lazy::new(|| {
+        <Parameters<DefaultFieldTernary128>>::try_from(CONST_DEFAULT_TERNARY_128_BITS_PARAMERTERS)
+            .unwrap()
+    });

--- a/boolean_fhe/tests/boolean_fhe_test.rs
+++ b/boolean_fhe/tests/boolean_fhe_test.rs
@@ -1,4 +1,4 @@
-use boolean_fhe::{EvaluationKey, LWEType, SecretKeyPack, DEFAULT_100_BITS_PARAMERTERS};
+use boolean_fhe::{EvaluationKey, LWEType, SecretKeyPack, DEFAULT_TERNARY_128_BITS_PARAMERTERS};
 use rand::prelude::*;
 
 #[test]
@@ -7,7 +7,7 @@ fn test_nand() {
     let mut rng = rand::thread_rng();
 
     // set parameter
-    let params = DEFAULT_100_BITS_PARAMERTERS.clone();
+    let params = DEFAULT_TERNARY_128_BITS_PARAMERTERS.clone();
 
     let noise_max = (params.lwe_modulus_f64() / 16.0) as LWEType;
 


### PR DESCRIPTION
The default parameter only works for ternary secret.