### PR TITLE
typo fix and adding missing semicolons

### DIFF
--- a/algebra/src/modulus/native/mod.rs
+++ b/algebra/src/modulus/native/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 
 mod ops;
 
-/// Natvie modulus.
+/// Native modulus.
 ///
 /// - For `u8`, this type acts as `2⁸`
 /// - For `u16`, this type acts as `2¹⁶`

--- a/algebra/src/polynomial/field/coeff/add.rs
+++ b/algebra/src/polynomial/field/coeff/add.rs
@@ -12,7 +12,7 @@ impl<F: Field> FieldPolynomial<F> {
         self.iter()
             .zip(rhs)
             .zip(destination)
-            .for_each(|((&a, &b), c)| *c = F::add(a, b))
+            .for_each(|((&a, &b), c)| *c = F::add(a, b));
     }
 }
 

--- a/algebra/src/polynomial/field/coeff/mul.rs
+++ b/algebra/src/polynomial/field/coeff/mul.rs
@@ -9,21 +9,21 @@ use crate::{
 use super::FieldPolynomial;
 
 impl<F: Field> FieldPolynomial<F> {
-    /// Multiply `self` with the a scalar.
+    /// Multiply `self` with a scalar.
     #[inline]
     pub fn mul_scalar(mut self, scalar: <F as Field>::ValueT) -> Self {
         self.mul_scalar_assign(scalar);
         self
     }
 
-    /// Multiply `self` with the a scalar and assign self.
+    /// Multiply `self` with a scalar and assign self.
     #[inline]
     pub fn mul_scalar_assign(&mut self, scalar: <F as Field>::ValueT) {
         self.iter_mut()
             .for_each(|v| <F as Field>::MODULUS.reduce_mul_assign(v, scalar))
     }
 
-    /// Multiply `self` with the a scalar and add to self.
+    /// Multiply `self` with a scalar and add to self.
     #[inline]
     pub fn add_mul_scalar_assign(&mut self, rhs: &Self, scalar: <F as Field>::ValueT) {
         self.iter_mut()
@@ -31,21 +31,21 @@ impl<F: Field> FieldPolynomial<F> {
             .for_each(|(r, &v)| *r = <F as Field>::MODULUS.reduce_mul_add(v, scalar, *r))
     }
 
-    /// Multiply `self` with the a shoup scalar.
+    /// Multiply `self` with a shoup scalar.
     #[inline]
     pub fn mul_shoup_scalar(mut self, scalar: ShoupFactor<<F as Field>::ValueT>) -> Self {
         self.mul_shoup_scalar_assign(scalar);
         self
     }
 
-    /// Multiply `self` with the a shoup scalar and assign self.
+    /// Multiply `self` with a shoup scalar and assign self.
     #[inline]
     pub fn mul_shoup_scalar_assign(&mut self, scalar: ShoupFactor<<F as Field>::ValueT>) {
         self.iter_mut()
             .for_each(|v| <F as Field>::MODULUS_VALUE.reduce_mul_assign(v, scalar));
     }
 
-    /// Multiply `self` with the a shoup scalar and add to self.
+    /// Multiply `self` with a shoup scalar and add to self.
     #[inline]
     pub fn add_mul_shoup_scalar_assign(
         &mut self,
@@ -60,7 +60,7 @@ impl<F: Field> FieldPolynomial<F> {
 }
 
 impl<F: NttField> FieldPolynomial<F> {
-    /// Multiply `self` with the a polynomial.
+    /// Multiply `self` with a polynomial.
     #[inline]
     pub fn mul(self, rhs: Self, ntt_table: &<F as NttField>::Table) -> Self {
         let mut a = self.into_ntt_poly(ntt_table);

--- a/algebra/src/polynomial/field/coeff/sub.rs
+++ b/algebra/src/polynomial/field/coeff/sub.rs
@@ -15,7 +15,7 @@ impl<F: Field> FieldPolynomial<F> {
         self.iter()
             .zip(rhs)
             .zip(destination)
-            .for_each(|((&a, &b), c)| *c = F::MODULUS.reduce_sub(a, b))
+            .for_each(|((&a, &b), c)| *c = F::MODULUS.reduce_sub(a, b));
     }
 }
 

--- a/algebra/src/polynomial/field/ntt/add.rs
+++ b/algebra/src/polynomial/field/ntt/add.rs
@@ -15,7 +15,7 @@ impl<F: NttField> FieldNttPolynomial<F> {
         self.iter()
             .zip(rhs)
             .zip(destination)
-            .for_each(|((&a, &b), z)| *z = <F as Field>::MODULUS.reduce_add(a, b))
+            .for_each(|((&a, &b), z)| *z = <F as Field>::MODULUS.reduce_add(a, b));
     }
 }
 

--- a/algebra/src/polynomial/field/ntt/mul.rs
+++ b/algebra/src/polynomial/field/ntt/mul.rs
@@ -28,7 +28,7 @@ impl<F: NttField> FieldNttPolynomial<F> {
     pub fn add_mul_scalar_assign(&mut self, rhs: &Self, scalar: <F as Field>::ValueT) {
         self.iter_mut()
             .zip(rhs.iter())
-            .for_each(|(r, &v)| *r = <F as Field>::MODULUS.reduce_mul_add(v, scalar, *r))
+            .for_each(|(r, &v)| *r = <F as Field>::MODULUS.reduce_mul_add(v, scalar, *r));
     }
 
     /// Multiply `self` with a scalar.

--- a/algebra/src/polynomial/field/ntt/sub.rs
+++ b/algebra/src/polynomial/field/ntt/sub.rs
@@ -15,7 +15,7 @@ impl<F: NttField> FieldNttPolynomial<F> {
         self.iter()
             .zip(rhs)
             .zip(destination)
-            .for_each(|((&a, &b), z)| *z = <F as Field>::MODULUS.reduce_sub(a, b))
+            .for_each(|((&a, &b), z)| *z = <F as Field>::MODULUS.reduce_sub(a, b));
     }
 }
 

--- a/algebra/src/polynomial/numeric/coeff/add.rs
+++ b/algebra/src/polynomial/numeric/coeff/add.rs
@@ -35,6 +35,6 @@ impl<T: Copy> Polynomial<T> {
         self.iter()
             .zip(rhs)
             .zip(destination)
-            .for_each(|((&a, &b), c)| *c = modulus.reduce_add(a, b))
+            .for_each(|((&a, &b), c)| *c = modulus.reduce_add(a, b));
     }
 }


### PR DESCRIPTION
In this PR I fixed several typos and added missing semicolons.

**Changes:**
Corrected "Natvie modulus" to "Native modulus" in `algebra/src/modulus/native/mod.rs`.
Removed extra wording ("the a scalar" → "a scalar") and made similar grammatical fixes in `algebra/src/polynomial/field/coeff/mul.rs`.
In other files I added missing semicolons after `for_each` cycle.

