### PR TITLE
Fix typo: Rename detination to destination in rgsw/normal.rs

### DIFF
--- a/lattice/src/rgsw/normal.rs
+++ b/lattice/src/rgsw/normal.rs
@@ -153,15 +153,15 @@ impl<F: NttField> Rgsw<F> {
             .minus_s_m
             .iter()
             .map(|rlwe| {
-                let mut detination = Rlwe::zero(dimension);
+                let mut destination = Rlwe::zero(dimension);
                 rlwe.mul_ntt_rgsw_inplace(
                     ntt_rgsw,
                     ntt_table,
                     decompose_space,
                     median,
-                    &mut detination,
+                    &mut destination,
                 );
-                detination
+                destination
             })
             .collect();
 
@@ -171,15 +171,15 @@ impl<F: NttField> Rgsw<F> {
             .m
             .iter()
             .map(|rlwe| {
-                let mut detination = Rlwe::zero(dimension);
+                let mut destination = Rlwe::zero(dimension);
                 rlwe.mul_ntt_rgsw_inplace(
                     ntt_rgsw,
                     ntt_table,
                     decompose_space,
                     median,
-                    &mut detination,
+                    &mut destination,
                 );
-                detination
+                destination
             })
             .collect();
 


### PR DESCRIPTION


**Description:**
This PR fixes a spelling error in variable names within lattice/src/rgsw/normal.rs. The variable "detination" was incorrectly spelled and has been corrected to "destination" across multiple instances in the file.


This change improves code readability and consistency while fixing a spelling mistake.
