### PR TITLE
feat: add `primus_fft` and `primus_lattice`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ members = ["crates/*", "xtask"]
 resolver = "3"
 
 [workspace.dependencies]
+num-complex = "0.4"
 num-traits = "0.2"
 rand = "0.10.2"
+rustfft = "6"
 serde = { version = "1.0", features = ["derive"] }
 zeroize = "1.9"
 bytemuck = "1.25.0"

--- a/crates/primus_decompose/src/primitive/basis.rs
+++ b/crates/primus_decompose/src/primitive/basis.rs
@@ -375,4 +375,33 @@ impl<T: FheUint> ApproxSignedBasis<T> {
             }
         }
     }
+
+    /// Extract initial carry bits from `values` without copying or adjusting.
+    ///
+    /// This only supports power-of-two modulus (the common TFHE case).  For
+    /// non-power-of-two moduli, use [`init_value_carry_slice_to`] instead,
+    /// which also computes adjusted values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this basis was created for a non-power-of-two modulus (i.e.
+    /// any initialization mode other than [`ValueCarryInitMode::CarryOnly`]
+    /// or [`ValueCarryInitMode::Plain`]).
+    #[inline]
+    pub fn init_carry_slice(&self, values: &[T], carries: &mut [bool]) {
+        debug_assert_eq!(values.len(), carries.len());
+        match self.value_carry_init_mode {
+            ValueCarryInitMode::CarryOnly { mask } => {
+                values
+                    .iter()
+                    .zip(carries)
+                    .for_each(|(&v, c)| *c = !(v & mask).is_zero());
+            }
+            ValueCarryInitMode::Plain => carries.fill(false),
+            _ => panic!(
+                "init_carry_slice does not support non-power-of-two modulus \
+                 (mode requires value adjustment); use init_value_carry_slice_to instead"
+            ),
+        }
+    }
 }

--- a/crates/primus_decompose/src/primitive/basis.rs
+++ b/crates/primus_decompose/src/primitive/basis.rs
@@ -379,7 +379,7 @@ impl<T: FheUint> ApproxSignedBasis<T> {
     /// Extract initial carry bits from `values` without copying or adjusting.
     ///
     /// This only supports power-of-two modulus (the common TFHE case).  For
-    /// non-power-of-two moduli, use [`init_value_carry_slice_to`] instead,
+    /// non-power-of-two moduli, use [`Self::init_value_carry_slice_to`] instead,
     /// which also computes adjusted values.
     ///
     /// # Panics

--- a/crates/primus_fft/Cargo.toml
+++ b/crates/primus_fft/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "primus_fft"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+primus_data = { path = "../primus_data" }
+primus_integer = { path = "../primus_integer" }
+num-complex = { workspace = true }
+rustfft = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+default = []

--- a/crates/primus_fft/src/complex64/arithmetic.rs
+++ b/crates/primus_fft/src/complex64/arithmetic.rs
@@ -1,0 +1,26 @@
+use num_complex::Complex64;
+
+/// Pointwise fused multiply-add: `accumulator[i] += lhs[i] * rhs[i]` for all `i`.
+///
+/// This is the hot-path accumulation used in external product and CMUX
+/// operations. All slices must have the same length.
+#[inline]
+pub fn add_mul_assign(accumulator: &mut [Complex64], lhs: &[Complex64], rhs: &[Complex64]) {
+    debug_assert_eq!(accumulator.len(), lhs.len());
+    debug_assert_eq!(accumulator.len(), rhs.len());
+    for (acc, (&l, &r)) in accumulator.iter_mut().zip(lhs.iter().zip(rhs.iter())) {
+        *acc += l * r;
+    }
+}
+
+/// Pointwise multiply: `output[i] = lhs[i] * rhs[i]` for all `i`.
+///
+/// All slices must have the same length.
+#[inline]
+pub fn mul_to(lhs: &[Complex64], rhs: &[Complex64], output: &mut [Complex64]) {
+    debug_assert_eq!(lhs.len(), output.len());
+    debug_assert_eq!(rhs.len(), output.len());
+    for ((&l, &r), out) in lhs.iter().zip(rhs.iter()).zip(output.iter_mut()) {
+        *out = l * r;
+    }
+}

--- a/crates/primus_fft/src/complex64/mod.rs
+++ b/crates/primus_fft/src/complex64/mod.rs
@@ -1,0 +1,5 @@
+/// Pointwise complex arithmetic kernels.
+pub mod arithmetic;
+mod table;
+
+pub use table::FullComplex64FftTable;

--- a/crates/primus_fft/src/complex64/table.rs
+++ b/crates/primus_fft/src/complex64/table.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use num_complex::Complex64;
+use rustfft::{Fft, FftPlanner};
+
+use crate::error::FftError;
+use crate::table::FftTable;
+use crate::torus::TorusFftValue;
+
+/// Full-length complex negacyclic FFT table backed by `rustfft`.
+///
+/// This is the **reference backend**: it stores the full `N` complex values
+/// (`fourier_length == poly_length == N`). It is simple and correct, making it
+/// suitable for testing and for verifying correctness of optimized backends.
+///
+/// # TFHE storage note
+///
+/// Production TFHE typically stores only `N / 2` complex values by exploiting
+/// real-input conjugate symmetry. A `PackedComplex64FftTable` backend will be
+/// added later to match this convention. Until then, Fourier ciphertext types
+/// that use this table will carry the full-length representation.
+///
+/// Pre-computes twist factors `psi^j` for `j = 0..N-1` where
+/// `psi = exp(pi * i / N)`, together with the scaled inverse twist factors
+/// `conj(psi^j) / N` so the inverse transform only needs a single complex
+/// multiply per coefficient.
+pub struct FullComplex64FftTable {
+    log_n: u32,
+    poly_length: usize,
+    fourier_length: usize,
+    forward: Arc<dyn Fft<f64>>,
+    inverse: Arc<dyn Fft<f64>>,
+    twist: Vec<Complex64>,
+    inv_twist_scaled: Vec<Complex64>,
+}
+
+impl FullComplex64FftTable {
+    /// Returns `log2(N)`.
+    #[inline]
+    pub fn log_n(&self) -> u32 {
+        self.log_n
+    }
+}
+
+impl FftTable for FullComplex64FftTable {
+    fn new(log_n: u32) -> Result<Self, FftError> {
+        // Guard against overflow: 1usize << log_n must be valid.
+        if log_n >= usize::BITS {
+            return Err(FftError::InvalidLogN {
+                log_n,
+                max: usize::BITS - 1,
+            });
+        }
+
+        let n = 1usize << log_n;
+
+        let mut planner = FftPlanner::new();
+        let forward = planner.plan_fft_forward(n);
+        let inverse = planner.plan_fft_inverse(n);
+
+        // Twist factors: psi^j where psi = exp(pi * i / N)
+        let angle = std::f64::consts::PI / n as f64;
+        let psi = Complex64::cis(angle);
+        let twist: Vec<Complex64> = std::iter::successors(Some(Complex64::new(1.0, 0.0)), |&z| {
+            Some(z * psi)
+        })
+        .take(n)
+        .collect();
+
+        // Scaled inverse twist: conj(psi^j) / N
+        let inv_n = n as f64;
+        let inv_twist_scaled: Vec<Complex64> = twist.iter().map(|t| t.conj() / inv_n).collect();
+
+        Ok(Self {
+            log_n,
+            poly_length: n,
+            fourier_length: n,
+            forward,
+            inverse,
+            twist,
+            inv_twist_scaled,
+        })
+    }
+
+    #[inline]
+    fn poly_length(&self) -> usize {
+        self.poly_length
+    }
+
+    #[inline]
+    fn fourier_length(&self) -> usize {
+        self.fourier_length
+    }
+
+    fn forward_torus_slice<T: TorusFftValue>(&self, input: &[T], output: &mut [Complex64]) {
+        debug_assert_eq!(input.len(), self.poly_length);
+        debug_assert_eq!(output.len(), self.fourier_length);
+
+        // Step 1: center and twist, writing directly into the output buffer.
+        for (j, &val) in input.iter().enumerate() {
+            let centered = val.into_f64_centered();
+            output[j] = Complex64::new(centered, 0.0) * self.twist[j];
+        }
+
+        // Step 2: in-place FFT on the twisted values.
+        self.forward.process(output);
+    }
+
+    fn inverse_torus_slice<T: TorusFftValue>(&self, input: &[Complex64], output: &mut [T]) {
+        debug_assert_eq!(input.len(), self.fourier_length);
+        debug_assert_eq!(output.len(), self.poly_length);
+
+        // Step 1: copy input to a temporary buffer for in-place IFFT.
+        // Allocation is acceptable for Milestone 1 correctness; future
+        // milestones will add caller-provided scratch space.
+        let mut buf: Vec<Complex64> = input.to_vec();
+
+        // Step 2: in-place inverse FFT (rustfft does NOT scale by 1/N).
+        self.inverse.process(&mut buf);
+
+        // Step 3: untwist, take real part, round, and store as torus integer.
+        for (j, val) in buf.iter().enumerate() {
+            let v = *val * self.inv_twist_scaled[j];
+            output[j] = T::from_f64_wrapping_rounded(v.re);
+        }
+    }
+
+}

--- a/crates/primus_fft/src/complex64/table.rs
+++ b/crates/primus_fft/src/complex64/table.rs
@@ -1,3 +1,4 @@
+use std::f64::consts::PI;
 use std::sync::Arc;
 
 use num_complex::Complex64;
@@ -58,18 +59,20 @@ impl FftTable for FullComplex64FftTable {
         let forward = planner.plan_fft_forward(n);
         let inverse = planner.plan_fft_inverse(n);
 
-        // Twist factors: psi^j where psi = exp(pi * i / N)
-        let angle = std::f64::consts::PI / n as f64;
-        let psi = Complex64::cis(angle);
-        let twist: Vec<Complex64> = std::iter::successors(Some(Complex64::new(1.0, 0.0)), |&z| {
-            Some(z * psi)
-        })
-        .take(n)
-        .collect();
+        // Twist factors: psi^j where psi = exp(pi * i / N).
+        // Using cis(PI * j / N) gives one rounding (the division) instead of
+        // two (pre-rounding PI/N, then multiplying by j).  The iterative
+        // z * psi approach is avoided because its round-off accumulates
+        // over O(N) steps.
+        let n_f64 = n as f64;
+        let twist: Vec<Complex64> = (0..n)
+            .map(|j| Complex64::cis(PI * j as f64 / n_f64))
+            .collect();
 
-        // Scaled inverse twist: conj(psi^j) / N
-        let inv_n = n as f64;
-        let inv_twist_scaled: Vec<Complex64> = twist.iter().map(|t| t.conj() / inv_n).collect();
+        // Scaled inverse twist: conj(psi^j) / N = cis(-PI * j / N) / N.
+        let inv_twist_scaled: Vec<Complex64> = (0..n)
+            .map(|j| Complex64::cis(-PI * j as f64 / n_f64) / n_f64)
+            .collect();
 
         Ok(Self {
             log_n,
@@ -124,5 +127,4 @@ impl FftTable for FullComplex64FftTable {
             output[j] = T::from_f64_wrapping_rounded(v.re);
         }
     }
-
 }

--- a/crates/primus_fft/src/error.rs
+++ b/crates/primus_fft/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+/// Errors that may occur during FFT table construction or operations.
+#[derive(Error, Debug)]
+pub enum FftError {
+    /// The requested `log_n` is too large.
+    ///
+    /// `1usize << log_n` must be valid, so `log_n` must be less than
+    /// `usize::BITS`.
+    #[error("log_n {log_n} is too large; must be less than {max}")]
+    InvalidLogN {
+        /// The requested log2(N).
+        log_n: u32,
+        /// The maximum allowed value.
+        max: u32,
+    },
+}

--- a/crates/primus_fft/src/lib.rs
+++ b/crates/primus_fft/src/lib.rs
@@ -1,0 +1,28 @@
+#![deny(missing_docs)]
+//! Torus negacyclic FFT transforms for `Z[X] / (X^N + 1)`.
+//!
+//! Provides the [`FftTable`] trait and the [`FullComplex64FftTable`] reference
+//! backend backed by the `rustfft` crate. The forward transform centers torus
+//! coefficients, applies a negacyclic twist, and performs a standard complex
+//! FFT. The inverse applies an IFFT, untwists, and rounds back to the torus
+//! representation.
+//!
+//! # Backends
+//!
+//! - [`FullComplex64FftTable`]: stores the full `N` complex values
+//!   (`fourier_length == poly_length`). Simple and correct — suitable as a
+//!   reference and for testing.
+//! - A future `PackedComplex64FftTable` will exploit real-input conjugate
+//!   symmetry to store only `N / 2` complex values, matching the storage
+//!   convention of production TFHE implementations.
+
+/// Interleaved `Complex64` FFT backend.
+pub mod complex64;
+mod error;
+mod table;
+mod torus;
+
+pub use complex64::FullComplex64FftTable;
+pub use error::FftError;
+pub use table::FftTable;
+pub use torus::TorusFftValue;

--- a/crates/primus_fft/src/table.rs
+++ b/crates/primus_fft/src/table.rs
@@ -26,7 +26,7 @@ pub trait FftTable: Send + Sync {
     /// The relationship between `poly_length` and `fourier_length` depends on
     /// the backend:
     ///
-    /// - [`FullComplex64FftTable`] stores the full `N` complex values
+    /// - [`FullComplex64FftTable`](crate::complex64::FullComplex64FftTable) stores the full `N` complex values
     ///   (`fourier_length == poly_length`). This is the reference backend.
     /// - A future packed backend will exploit real-input symmetry to store only
     ///   `N / 2` complex values (`fourier_length == poly_length / 2`).

--- a/crates/primus_fft/src/table.rs
+++ b/crates/primus_fft/src/table.rs
@@ -1,0 +1,50 @@
+use num_complex::Complex64;
+
+use crate::error::FftError;
+use crate::torus::TorusFftValue;
+
+/// Abstract interface for torus negacyclic FFT tables.
+///
+/// Implementations provide forward and inverse negacyclic transforms for
+/// polynomial multiplication in `Z[X] / (X^N + 1)`.
+///
+/// # Thread safety
+///
+/// Implementations must be `Send + Sync` so tables can be shared across
+/// threads (read-only) without additional synchronization.
+pub trait FftTable: Send + Sync {
+    /// Create a new FFT table for the negacyclic transform of size `N = 2^log_n`.
+    fn new(log_n: u32) -> Result<Self, FftError>
+    where
+        Self: Sized;
+
+    /// The polynomial length `N`.
+    fn poly_length(&self) -> usize;
+
+    /// The length of the Fourier representation.
+    ///
+    /// The relationship between `poly_length` and `fourier_length` depends on
+    /// the backend:
+    ///
+    /// - [`FullComplex64FftTable`] stores the full `N` complex values
+    ///   (`fourier_length == poly_length`). This is the reference backend.
+    /// - A future packed backend will exploit real-input symmetry to store only
+    ///   `N / 2` complex values (`fourier_length == poly_length / 2`).
+    ///
+    /// Callers must always allocate Fourier buffers using this value, never
+    /// derive it from `poly_length` directly.
+    fn fourier_length(&self) -> usize;
+
+    /// Forward negacyclic transform: torus coefficients → Fourier domain.
+    ///
+    /// `input` must have length [`poly_length()`](FftTable::poly_length).
+    /// `output` receives [`fourier_length()`](FftTable::fourier_length) complex
+    /// values.
+    fn forward_torus_slice<T: TorusFftValue>(&self, input: &[T], output: &mut [Complex64]);
+
+    /// Inverse negacyclic transform: Fourier domain → torus coefficients.
+    ///
+    /// `input` must have length [`fourier_length()`](FftTable::fourier_length).
+    /// `output` receives [`poly_length()`](FftTable::poly_length) torus values.
+    fn inverse_torus_slice<T: TorusFftValue>(&self, input: &[Complex64], output: &mut [T]);
+}

--- a/crates/primus_fft/src/torus.rs
+++ b/crates/primus_fft/src/torus.rs
@@ -1,0 +1,70 @@
+use primus_integer::FheUint;
+
+/// Conversion between torus (integer) values and centered floating-point
+/// representation for negacyclic FFT.
+///
+/// # Centered representation
+///
+/// A torus value `x` in `[0, 2^BITS)` is mapped to the centered range
+/// `[-2^(BITS-1), 2^(BITS-1) - 1]` by reinterpreting the bit pattern as a
+/// signed integer of the same width, then widening to `f64`.
+///
+/// # Precision notes
+///
+/// - `u32`: exact, because `f64` has 53 mantissa bits so every `u32` value
+///   is representable.
+/// - `u64`: values above `2^53` lose integer precision in `f64`. This is
+///   acceptable for noise terms in FHE but users should be aware of the limit.
+///   A future split/high-low or double-double precision backend can strengthen
+///   this without changing the high-level lattice APIs.
+pub trait TorusFftValue: FheUint {
+    /// Convert `self` (a torus/unsigned value) to a centered `f64`.
+    ///
+    /// Maps `[0, 2^BITS)` to `[-2^(BITS-1), 2^(BITS-1) - 1]` via a
+    /// signed-integer reinterpret cast.
+    fn into_f64_centered(self) -> f64;
+
+    /// Convert a centered `f64` back to the torus value, rounding to nearest
+    /// integer and wrapping modulo `2^BITS`.
+    fn from_f64_wrapping_rounded(value: f64) -> Self;
+}
+
+impl TorusFftValue for u32 {
+    #[inline]
+    fn into_f64_centered(self) -> f64 {
+        (self as i32) as f64
+    }
+
+    #[inline]
+    fn from_f64_wrapping_rounded(value: f64) -> Self {
+        // Use i64 intermediate so values that round to i32::MIN (as an i64)
+        // are correctly cast back to u32 without going through i32 overflow.
+        (value.round() as i64) as u32
+    }
+}
+
+impl TorusFftValue for u64 {
+    #[inline]
+    fn into_f64_centered(self) -> f64 {
+        // WARNING: f64 has 53-bit mantissa; values above 2^53 lose precision.
+        (self as i64) as f64
+    }
+
+    #[inline]
+    fn from_f64_wrapping_rounded(value: f64) -> Self {
+        // Use i128 intermediate to avoid truncation issues at the i64 boundary.
+        (value.round() as i128) as u64
+    }
+}
+
+impl TorusFftValue for u16 {
+    #[inline]
+    fn into_f64_centered(self) -> f64 {
+        (self as i16) as f64
+    }
+
+    #[inline]
+    fn from_f64_wrapping_rounded(value: f64) -> Self {
+        (value.round() as i32) as u16
+    }
+}

--- a/crates/primus_fft/tests/negacyclic.rs
+++ b/crates/primus_fft/tests/negacyclic.rs
@@ -1,0 +1,245 @@
+use num_complex::Complex64;
+use primus_fft::complex64::arithmetic;
+use primus_fft::{FullComplex64FftTable, FftTable};
+
+// ---------------------------------------------------------------------------
+// Helper: naive negacyclic convolution (X^N + 1)
+// ---------------------------------------------------------------------------
+
+/// Compute `a * b mod (X^N + 1)` using direct O(N^2) convolution with `i64`
+/// intermediates to avoid overflow.
+///
+/// Coefficients are in torus (u32) representation and are interpreted as
+/// centered `i32` values for multiplication. The result is wrapped back to
+/// u32 with centered semantics.
+fn naive_negacyclic_convolve_u32(a: &[u32], b: &[u32]) -> Vec<u32> {
+    let n = a.len();
+    // Use i64 to accumulate; the max magnitude in tests is small enough.
+    let mut c = vec![0i64; n];
+
+    for i in 0..n {
+        let a_c = a[i] as i32 as i64;
+        for j in 0..n {
+            let b_c = b[j] as i32 as i64;
+            let prod = a_c * b_c;
+            let idx = i + j;
+            if idx < n {
+                c[idx] += prod;
+            } else {
+                c[idx - n] -= prod;
+            }
+        }
+    }
+
+    // Wrap i64 back to u32 with centered semantics: reinterpret as i32, then as u32.
+    c.iter().map(|&x| (x as i32) as u32).collect()
+}
+
+/// Compute `a * b mod (X^N - 1)` (cyclic convolution) using direct O(N^2).
+///
+/// Used to demonstrate that raw cyclic FFT (without negacyclic twist) produces
+/// a different product.
+fn naive_cyclic_convolve_u32(a: &[u32], b: &[u32]) -> Vec<u32> {
+    let n = a.len();
+    let mut c = vec![0i64; n];
+
+    for i in 0..n {
+        let a_c = a[i] as i32 as i64;
+        for j in 0..n {
+            let b_c = b[j] as i32 as i64;
+            let prod = a_c * b_c;
+            let idx = (i + j) % n;
+            c[idx] += prod;
+        }
+    }
+
+    c.iter().map(|&x| (x as i32) as u32).collect()
+}
+
+/// Negacyclic product via FFT: forward → pointwise mul → inverse.
+fn fft_negacyclic_product(table: &FullComplex64FftTable, a: &[u32], b: &[u32]) -> Vec<u32> {
+    let n = table.poly_length();
+    let flen = table.fourier_length();
+    assert_eq!(a.len(), n);
+    assert_eq!(b.len(), n);
+
+    let mut fa = vec![Complex64::new(0.0, 0.0); flen];
+    let mut fb = vec![Complex64::new(0.0, 0.0); flen];
+
+    table.forward_torus_slice(a, &mut fa);
+    table.forward_torus_slice(b, &mut fb);
+
+    let mut fc = vec![Complex64::new(0.0, 0.0); flen];
+    arithmetic::mul_to(&fa, &fb, &mut fc);
+
+    let mut c = vec![0u32; n];
+    table.inverse_torus_slice(&fc, &mut c);
+    c
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// FFT-based negacyclic product must match the naive O(N^2) X^N+1 convolution
+/// for small coefficients across a range of sizes.
+#[test]
+fn negacyclic_mul_matches_naive_u32() {
+    for log_n in 1..=6 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+
+        // Coefficients in [-2, -1, 0, 1, 2] (centered), wrapped to u32
+        let a: Vec<u32> = (0..n)
+            .map(|i| match i % 5 {
+                0 => 0u32,
+                1 => 1u32,
+                2 => (-1i32) as u32,
+                3 => 2u32,
+                _ => (-2i32) as u32,
+            })
+            .collect();
+
+        let b: Vec<u32> = (0..n)
+            .map(|i| match (i / 2) % 5 {
+                0 => 0u32,
+                1 => (-1i32) as u32,
+                2 => 1u32,
+                3 => (-2i32) as u32,
+                _ => 2u32,
+            })
+            .collect();
+
+        let expected = naive_negacyclic_convolve_u32(&a, &b);
+        let actual = fft_negacyclic_product(&table, &a, &b);
+
+        assert_eq!(
+            expected, actual,
+            "negacyclic_mul_matches_naive_u32 failed for log_n={log_n}"
+        );
+    }
+}
+
+/// The negacyclic twist is essential: a cyclic (X^N-1) product differs from
+/// the negacyclic (X^N+1) product for non-trivial inputs.
+#[test]
+fn raw_cyclic_fft_is_not_used() {
+    let log_n = 4;
+    let table = FullComplex64FftTable::new(log_n).unwrap();
+    let n = table.poly_length();
+
+    // Non-trivial polynomials
+    let a: Vec<u32> = (0..n).map(|i| (i as i32) as u32).collect();
+    let b: Vec<u32> = (0..n).map(|i| ((i * 3) as i32) as u32).collect();
+
+    let negacyclic = fft_negacyclic_product(&table, &a, &b);
+    let cyclic = naive_cyclic_convolve_u32(&a, &b);
+
+    assert_ne!(
+        negacyclic, cyclic,
+        "negacyclic product must differ from cyclic product for non-trivial inputs"
+    );
+}
+
+/// Multiplying by `X^d` (monomial with coefficient 1 at position `d`) should
+/// rotate coefficients and flip signs on wrap-around past degree `N-1`.
+#[test]
+fn monomial_mul_matches_negacyclic_rotation() {
+    let log_n = 4;
+    let table = FullComplex64FftTable::new(log_n).unwrap();
+    let n = table.poly_length();
+
+    // Polynomial a(x) = 1 + 2*x + 3*x^2 + 4*x^3 + ...
+    let mut a = vec![0u32; n];
+    for i in 0..4.min(n) {
+        a[i] = (i + 1) as i32 as u32;
+    }
+
+    for d in [0, 1, 3, n - 1] {
+        // Monomial X^d
+        let mut monomial = vec![0u32; n];
+        monomial[d] = 1;
+
+        let result = fft_negacyclic_product(&table, &monomial, &a);
+
+        // Expected: X^d * a(x) mod (X^N + 1)
+        // For each i where a[i] != 0:
+        //   result[i + d] = a[i] if i + d < n
+        //   result[i + d - n] = -a[i] if i + d >= n (sign flips on wrap)
+        let mut expected = vec![0u32; n];
+        for i in 0..n {
+            if a[i] != 0 {
+                let idx = i + d;
+                if idx < n {
+                    expected[idx] = a[i];
+                } else {
+                    expected[idx - n] = 0u32.wrapping_sub(a[i]);
+                }
+            }
+        }
+
+        assert_eq!(
+            result, expected,
+            "monomial multiplication failed for d={d}"
+        );
+    }
+}
+
+/// Zero polynomial times anything = zero.
+/// Constant-1 polynomial is the multiplicative identity.
+/// Constant (u32::MAX) = -1 should negate the polynomial.
+#[test]
+fn zero_and_one_polynomials() {
+    let log_n = 4;
+    let table = FullComplex64FftTable::new(log_n).unwrap();
+    let n = table.poly_length();
+
+    let a: Vec<u32> = (0..n)
+        .map(|i| {
+            (match i % 5 {
+                0 => 2,
+                1 => -1,
+                2 => 0,
+                3 => 1,
+                _ => -2,
+            }) as i32 as u32
+        })
+        .collect();
+
+    // 0 * a == 0
+    let zero = vec![0u32; n];
+    let result_zero = fft_negacyclic_product(&table, &zero, &a);
+    assert_eq!(result_zero, zero, "zero polynomial times a should be zero");
+
+    // 1 * a == a
+    let mut one = vec![0u32; n];
+    one[0] = 1;
+    let result_one = fft_negacyclic_product(&table, &one, &a);
+    assert_eq!(result_one, a, "one polynomial times a should be a");
+
+    // (-1) * a == -a (wrapping negation)
+    let mut minus_one = vec![0u32; n];
+    minus_one[0] = 0u32.wrapping_sub(1); // u32::MAX, representing -1
+    let result_minus_one = fft_negacyclic_product(&table, &minus_one, &a);
+    let neg_a: Vec<u32> = a.iter().map(|&x| 0u32.wrapping_sub(x)).collect();
+    assert_eq!(
+        result_minus_one, neg_a,
+        "(-1) polynomial times a should be -a"
+    );
+}
+
+/// Monomial at degree 0 (X^0 = 1) is the identity element.
+#[test]
+fn monomial_degree_zero_is_identity() {
+    let log_n = 4;
+    let table = FullComplex64FftTable::new(log_n).unwrap();
+    let n = table.poly_length();
+
+    let a: Vec<u32> = (0..n).map(|i| (i as i32) as u32).collect();
+
+    let mut identity = vec![0u32; n];
+    identity[0] = 1;
+
+    let result = fft_negacyclic_product(&table, &identity, &a);
+    assert_eq!(result, a, "X^0 * a should equal a");
+}

--- a/crates/primus_fft/tests/negacyclic.rs
+++ b/crates/primus_fft/tests/negacyclic.rs
@@ -17,10 +17,10 @@ fn naive_negacyclic_convolve_u32(a: &[u32], b: &[u32]) -> Vec<u32> {
     // Use i64 to accumulate; the max magnitude in tests is small enough.
     let mut c = vec![0i64; n];
 
-    for i in 0..n {
-        let a_c = a[i] as i32 as i64;
-        for j in 0..n {
-            let b_c = b[j] as i32 as i64;
+    for (i, &ai) in a.iter().enumerate() {
+        let a_c = ai as i32 as i64;
+        for (j, &bj) in b.iter().enumerate() {
+            let b_c = bj as i32 as i64;
             let prod = a_c * b_c;
             let idx = i + j;
             if idx < n {
@@ -43,10 +43,10 @@ fn naive_cyclic_convolve_u32(a: &[u32], b: &[u32]) -> Vec<u32> {
     let n = a.len();
     let mut c = vec![0i64; n];
 
-    for i in 0..n {
-        let a_c = a[i] as i32 as i64;
-        for j in 0..n {
-            let b_c = b[j] as i32 as i64;
+    for (i, &ai) in a.iter().enumerate() {
+        let a_c = ai as i32 as i64;
+        for (j, &bj) in b.iter().enumerate() {
+            let b_c = bj as i32 as i64;
             let prod = a_c * b_c;
             let idx = (i + j) % n;
             c[idx] += prod;
@@ -151,8 +151,8 @@ fn monomial_mul_matches_negacyclic_rotation() {
 
     // Polynomial a(x) = 1 + 2*x + 3*x^2 + 4*x^3 + ...
     let mut a = vec![0u32; n];
-    for i in 0..4.min(n) {
-        a[i] = (i + 1) as i32 as u32;
+    for (i, ai) in a.iter_mut().enumerate().take(4.min(n)) {
+        *ai = (i + 1) as i32 as u32;
     }
 
     for d in [0, 1, 3, n - 1] {
@@ -167,13 +167,13 @@ fn monomial_mul_matches_negacyclic_rotation() {
         //   result[i + d] = a[i] if i + d < n
         //   result[i + d - n] = -a[i] if i + d >= n (sign flips on wrap)
         let mut expected = vec![0u32; n];
-        for i in 0..n {
-            if a[i] != 0 {
+        for (i, &ai) in a.iter().enumerate() {
+            if ai != 0 {
                 let idx = i + d;
                 if idx < n {
-                    expected[idx] = a[i];
+                    expected[idx] = ai;
                 } else {
-                    expected[idx - n] = 0u32.wrapping_sub(a[i]);
+                    expected[idx - n] = 0u32.wrapping_sub(ai);
                 }
             }
         }
@@ -192,14 +192,12 @@ fn zero_and_one_polynomials() {
     let n = table.poly_length();
 
     let a: Vec<u32> = (0..n)
-        .map(|i| {
-            (match i % 5 {
-                0 => 2,
-                1 => -1,
-                2 => 0,
-                3 => 1,
-                _ => -2,
-            }) as i32 as u32
+        .map(|i| match i % 5 {
+            0 => 2u32,
+            1 => (-1i32) as u32,
+            2 => 0,
+            3 => 1,
+            _ => (-2i32) as u32,
         })
         .collect();
 

--- a/crates/primus_fft/tests/negacyclic.rs
+++ b/crates/primus_fft/tests/negacyclic.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex64;
 use primus_fft::complex64::arithmetic;
-use primus_fft::{FullComplex64FftTable, FftTable};
+use primus_fft::{FftTable, FullComplex64FftTable};
 
 // ---------------------------------------------------------------------------
 // Helper: naive negacyclic convolution (X^N + 1)
@@ -178,10 +178,7 @@ fn monomial_mul_matches_negacyclic_rotation() {
             }
         }
 
-        assert_eq!(
-            result, expected,
-            "monomial multiplication failed for d={d}"
-        );
+        assert_eq!(result, expected, "monomial multiplication failed for d={d}");
     }
 }
 

--- a/crates/primus_fft/tests/roundtrip.rs
+++ b/crates/primus_fft/tests/roundtrip.rs
@@ -1,0 +1,167 @@
+use num_complex::Complex64;
+use primus_fft::{FullComplex64FftTable, FftTable};
+
+/// Small centered coefficients should roundtrip exactly through
+/// forward + inverse transform for all N from 2 to 64.
+#[test]
+fn roundtrip_u32_small() {
+    for log_n in 1..=6 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+        let flen = table.fourier_length();
+
+        let mut fourier = vec![Complex64::new(0.0, 0.0); flen];
+        let mut output = vec![0u32; n];
+
+        // Test pattern: small centered values [-2, -1, 0, 1, 2] (wrapped to u32)
+        let input: Vec<u32> = (0..n)
+            .map(|i| match i % 5 {
+                0 => 0u32,
+                1 => 1u32,
+                2 => (-1i32) as u32,
+                3 => 2u32,
+                _ => (-2i32) as u32,
+            })
+            .collect();
+
+        table.forward_torus_slice(&input, &mut fourier);
+        table.inverse_torus_slice(&fourier, &mut output);
+        assert_eq!(
+            input, output,
+            "roundtrip_u32_small failed for log_n={log_n}"
+        );
+    }
+}
+
+/// A single non-zero coefficient (monomial) should roundtrip exactly.
+#[test]
+fn roundtrip_u32_monomial() {
+    for log_n in 1..=6 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+        let flen = table.fourier_length();
+
+        let mut fourier = vec![Complex64::new(0.0, 0.0); flen];
+        let mut output = vec![0u32; n];
+
+        for pos in [0, 1, n / 2, n - 1] {
+            let mut input = vec![0u32; n];
+            input[pos] = 1;
+
+            fourier.fill(Complex64::new(0.0, 0.0));
+            output.fill(0);
+
+            table.forward_torus_slice(&input, &mut fourier);
+            table.inverse_torus_slice(&fourier, &mut output);
+            assert_eq!(
+                input, output,
+                "roundtrip_u32_monomial failed for log_n={log_n}, pos={pos}"
+            );
+        }
+    }
+}
+
+/// All-zeros polynomial roundtrips exactly.
+#[test]
+fn roundtrip_zero_polynomial() {
+    for log_n in 1..=6 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+        let flen = table.fourier_length();
+
+        let input = vec![0u32; n];
+        let mut fourier = vec![Complex64::new(0.0, 0.0); flen];
+        let mut output = vec![1u32; n]; // start with non-zero to catch failures
+
+        table.forward_torus_slice(&input, &mut fourier);
+        table.inverse_torus_slice(&fourier, &mut output);
+        assert_eq!(
+            input, output,
+            "roundtrip_zero_polynomial failed for log_n={log_n}"
+        );
+    }
+}
+
+/// Constant-1 polynomial roundtrips exactly (identity element).
+#[test]
+fn roundtrip_one_polynomial() {
+    for log_n in 1..=6 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+        let flen = table.fourier_length();
+
+        let mut input = vec![0u32; n];
+        input[0] = 1;
+
+        let mut fourier = vec![Complex64::new(0.0, 0.0); flen];
+        let mut output = vec![0u32; n];
+
+        table.forward_torus_slice(&input, &mut fourier);
+        table.inverse_torus_slice(&fourier, &mut output);
+        assert_eq!(
+            input, output,
+            "roundtrip_one_polynomial failed for log_n={log_n}"
+        );
+    }
+}
+
+/// u64 roundtrip for small values (within f64 exact integer range, |v| <= 2^53).
+#[test]
+fn roundtrip_u64_small() {
+    for log_n in 1..=4 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+        let flen = table.fourier_length();
+
+        let mut fourier = vec![Complex64::new(0.0, 0.0); flen];
+        let mut output = vec![0u64; n];
+
+        // Small values that fit exactly in f64 (53-bit mantissa)
+        let input: Vec<u64> = (0..n)
+            .map(|i| match i % 5 {
+                0 => 0u64,
+                1 => 1u64,
+                2 => (-1i64) as u64,
+                3 => 2u64,
+                _ => (-2i64) as u64,
+            })
+            .collect();
+
+        table.forward_torus_slice(&input, &mut fourier);
+        table.inverse_torus_slice(&fourier, &mut output);
+        assert_eq!(
+            input, output,
+            "roundtrip_u64_small failed for log_n={log_n}"
+        );
+    }
+}
+
+/// u16 roundtrip for small values.
+#[test]
+fn roundtrip_u16_small() {
+    for log_n in 1..=4 {
+        let table = FullComplex64FftTable::new(log_n).unwrap();
+        let n = table.poly_length();
+        let flen = table.fourier_length();
+
+        let mut fourier = vec![Complex64::new(0.0, 0.0); flen];
+        let mut output = vec![0u16; n];
+
+        let input: Vec<u16> = (0..n)
+            .map(|i| match i % 5 {
+                0 => 0u16,
+                1 => 1u16,
+                2 => (-1i16) as u16,
+                3 => 2u16,
+                _ => (-2i16) as u16,
+            })
+            .collect();
+
+        table.forward_torus_slice(&input, &mut fourier);
+        table.inverse_torus_slice(&fourier, &mut output);
+        assert_eq!(
+            input, output,
+            "roundtrip_u16_small failed for log_n={log_n}"
+        );
+    }
+}

--- a/crates/primus_fft/tests/roundtrip.rs
+++ b/crates/primus_fft/tests/roundtrip.rs
@@ -1,5 +1,5 @@
 use num_complex::Complex64;
-use primus_fft::{FullComplex64FftTable, FftTable};
+use primus_fft::{FftTable, FullComplex64FftTable};
 
 /// Small centered coefficients should roundtrip exactly through
 /// forward + inverse transform for all N from 2 to 64.

--- a/crates/primus_lattice/Cargo.toml
+++ b/crates/primus_lattice/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "primus_lattice"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+primus_data = { path = "../primus_data" }
+primus_integer = { path = "../primus_integer" }
+primus_reduce = { path = "../primus_reduce" }
+primus_modulo = { path = "../primus_modulo" }
+primus_factor = { path = "../primus_factor" }
+primus_distr = { path = "../primus_distr" }
+primus_poly = { path = "../primus_poly" }
+primus_ntt = { path = "../primus_ntt" }
+primus_rns = { path = "../primus_rns" }
+primus_decompose = { path = "../primus_decompose" }
+
+serde = { workspace = true }
+bytemuck = { workspace = true }
+rand = { workspace = true }
+paste = { workspace = true }
+itertools = { workspace = true }
+
+[features]
+default = []
+simd = [
+    "primus_integer/simd",
+    "primus_factor/simd",
+    "primus_poly/simd",
+    "primus_ntt/simd",
+    "primus_rns/simd",
+    "primus_decompose/simd",
+]

--- a/crates/primus_lattice/Cargo.toml
+++ b/crates/primus_lattice/Cargo.toml
@@ -14,7 +14,9 @@ primus_poly = { path = "../primus_poly" }
 primus_ntt = { path = "../primus_ntt" }
 primus_rns = { path = "../primus_rns" }
 primus_decompose = { path = "../primus_decompose" }
+primus_fft = { path = "../primus_fft" }
 
+num-complex = { workspace = true }
 serde = { workspace = true }
 bytemuck = { workspace = true }
 rand = { workspace = true }

--- a/crates/primus_lattice/src/context/glev.rs
+++ b/crates/primus_lattice/src/context/glev.rs
@@ -1,0 +1,57 @@
+use primus_integer::FheUint;
+
+pub struct DcrtGlevContext<T: FheUint> {
+    adjust_big_uint_values: Vec<T>,
+    decomposed_unsigned_values: Vec<T>,
+    carries: Vec<bool>,
+    multi_residues: Vec<T>,
+    compose_buffer: Vec<T>,
+}
+
+pub struct DcrtGlevContextRefMut<'a, T: FheUint> {
+    pub adjust_big_uint_values: &'a mut [T],
+    pub decomposed_unsigned_values: &'a mut [T],
+    pub carries: &'a mut [bool],
+    pub multi_residues: &'a mut [T],
+    pub compose_buffer: &'a mut [T],
+}
+
+impl<T: FheUint> DcrtGlevContext<T> {
+    pub fn new(
+        poly_length: usize,
+        crt_poly_len: usize,
+        big_uint_poly_len: usize,
+        moduli_count: usize,
+    ) -> Self {
+        Self {
+            adjust_big_uint_values: vec![T::ZERO; big_uint_poly_len],
+            decomposed_unsigned_values: vec![T::ZERO; poly_length],
+            carries: vec![false; poly_length],
+            multi_residues: vec![T::ZERO; crt_poly_len],
+            compose_buffer: vec![T::ZERO; moduli_count],
+        }
+    }
+
+    #[inline]
+    pub fn as_mut<'a>(&'a mut self) -> DcrtGlevContextRefMut<'a, T> {
+        DcrtGlevContextRefMut {
+            adjust_big_uint_values: &mut self.adjust_big_uint_values,
+            decomposed_unsigned_values: &mut self.decomposed_unsigned_values,
+            carries: &mut self.carries,
+            multi_residues: &mut self.multi_residues,
+            compose_buffer: &mut self.compose_buffer,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.adjust_big_uint_values.fill(T::ZERO);
+        self.decomposed_unsigned_values.fill(T::ZERO);
+        self.carries.fill(false);
+        self.multi_residues.fill(T::ZERO);
+        self.compose_buffer.fill(T::ZERO);
+    }
+
+    pub fn compose_buffer_mut(&mut self) -> &mut [T] {
+        &mut self.compose_buffer
+    }
+}

--- a/crates/primus_lattice/src/context/glev.rs
+++ b/crates/primus_lattice/src/context/glev.rs
@@ -1,5 +1,6 @@
 use primus_integer::FheUint;
 
+/// A working context for DCRT GLEV operations, holding temporary buffers for decomposition and recomposition.
 pub struct DcrtGlevContext<T: FheUint> {
     adjust_big_uint_values: Vec<T>,
     decomposed_unsigned_values: Vec<T>,
@@ -8,15 +9,22 @@ pub struct DcrtGlevContext<T: FheUint> {
     compose_buffer: Vec<T>,
 }
 
+/// A mutable reference view of [`DcrtGlevContext`] fields, used to borrow all buffers simultaneously.
 pub struct DcrtGlevContextRefMut<'a, T: FheUint> {
+    /// Buffer for big integer values adjusted during decomposition.
     pub adjust_big_uint_values: &'a mut [T],
+    /// Buffer for unsigned decomposed values.
     pub decomposed_unsigned_values: &'a mut [T],
+    /// Buffer tracking carries during decomposition.
     pub carries: &'a mut [bool],
+    /// Buffer for multi-residue values after CRT decomposition.
     pub multi_residues: &'a mut [T],
+    /// Buffer for composing values across moduli.
     pub compose_buffer: &'a mut [T],
 }
 
 impl<T: FheUint> DcrtGlevContext<T> {
+    /// Creates a new [`DcrtGlevContext`] allocated for the given polynomial and modulus dimensions.
     pub fn new(
         poly_length: usize,
         crt_poly_len: usize,
@@ -32,6 +40,7 @@ impl<T: FheUint> DcrtGlevContext<T> {
         }
     }
 
+    /// Returns a [`DcrtGlevContextRefMut`] that borrows all internal buffers mutably.
     #[inline]
     pub fn as_mut<'a>(&'a mut self) -> DcrtGlevContextRefMut<'a, T> {
         DcrtGlevContextRefMut {
@@ -43,6 +52,7 @@ impl<T: FheUint> DcrtGlevContext<T> {
         }
     }
 
+    /// Resets all buffers to their zero values.
     pub fn clear(&mut self) {
         self.adjust_big_uint_values.fill(T::ZERO);
         self.decomposed_unsigned_values.fill(T::ZERO);
@@ -51,6 +61,7 @@ impl<T: FheUint> DcrtGlevContext<T> {
         self.compose_buffer.fill(T::ZERO);
     }
 
+    /// Returns a mutable reference to the compose buffer.
     pub fn compose_buffer_mut(&mut self) -> &mut [T] {
         &mut self.compose_buffer
     }

--- a/crates/primus_lattice/src/context/mod.rs
+++ b/crates/primus_lattice/src/context/mod.rs
@@ -1,4 +1,5 @@
 mod glev;
+/// Scratch buffers for TFHE external product.
 pub mod tfhe;
 
 pub use glev::{DcrtGlevContext, DcrtGlevContextRefMut};

--- a/crates/primus_lattice/src/context/mod.rs
+++ b/crates/primus_lattice/src/context/mod.rs
@@ -1,3 +1,5 @@
 mod glev;
+pub mod tfhe;
 
 pub use glev::{DcrtGlevContext, DcrtGlevContextRefMut};
+pub use tfhe::TfheFftContext;

--- a/crates/primus_lattice/src/context/mod.rs
+++ b/crates/primus_lattice/src/context/mod.rs
@@ -1,0 +1,3 @@
+mod glev;
+
+pub use glev::{DcrtGlevContext, DcrtGlevContextRefMut};

--- a/crates/primus_lattice/src/context/tfhe.rs
+++ b/crates/primus_lattice/src/context/tfhe.rs
@@ -10,7 +10,8 @@ use primus_fft::TorusFftValue;
 ///
 /// `glwe_dimension` is the count of *mask* polynomials (`k`).  The
 /// accumulator is sized for `glwe_dimension + 1` polynomials (k mask
-/// + 1 body), matching the convention of [`Lwe::dimension()`].
+/// + 1 body), matching the convention of
+/// [`crate::lwe::Lwe::dimension()`].
 ///
 /// # Design note
 ///

--- a/crates/primus_lattice/src/context/tfhe.rs
+++ b/crates/primus_lattice/src/context/tfhe.rs
@@ -11,7 +11,7 @@ use primus_fft::TorusFftValue;
 /// `glwe_dimension` is the count of *mask* polynomials (`k`).  The
 /// accumulator is sized for `glwe_dimension + 1` polynomials (k mask
 /// + 1 body), matching the convention of
-/// [`crate::lwe::Lwe::dimension()`].
+///   [`crate::lwe::Lwe::dimension()`].
 ///
 /// # Design note
 ///

--- a/crates/primus_lattice/src/context/tfhe.rs
+++ b/crates/primus_lattice/src/context/tfhe.rs
@@ -1,0 +1,58 @@
+use num_complex::Complex64;
+use primus_fft::TorusFftValue;
+
+/// Pre-allocated scratch buffers for the TFHE external product.
+///
+/// All allocations happen at construction time.  The hot loop only
+/// mutates slices obtained directly from the public fields.
+///
+/// # GLWE dimension convention
+///
+/// `glwe_dimension` is the count of *mask* polynomials (`k`).  The
+/// accumulator is sized for `glwe_dimension + 1` polynomials (k mask
+/// + 1 body), matching the convention of [`Lwe::dimension()`].
+///
+/// # Design note
+///
+/// For power-of-two modulus (the common TFHE case), `init_value_carry_slice_to`
+/// would just copy the input into a temporary buffer before decomposition.
+/// We avoid that waste by reading directly from the input GLWE and using
+/// `ApproxSignedBasis::init_carry_slice` (only extracts carries, no copy).
+pub struct TfheFftContext<T: TorusFftValue> {
+    /// Carry bits, one per coefficient (length = `poly_length`).
+    pub carries: Vec<bool>,
+    /// Decomposed (signed) digits for one polynomial (length = `poly_length`).
+    pub decomposed_poly: Vec<T>,
+    /// FFT of the decomposed polynomial (length = `fourier_length`).
+    pub decomposed_fourier: Vec<Complex64>,
+    /// Accumulator in Fourier domain
+    /// (length = `(glwe_dimension + 1) * fourier_length`).
+    pub fourier_accumulator: Vec<Complex64>,
+}
+
+impl<T: TorusFftValue> TfheFftContext<T> {
+    /// Creates a new context with all buffers pre-allocated.
+    ///
+    /// `glwe_dimension` is the mask count `k`; the accumulator is sized for
+    /// `k + 1` polynomials.
+    pub fn new(poly_length: usize, fourier_length: usize, glwe_dimension: usize) -> Self {
+        let total_polys = glwe_dimension + 1;
+        Self {
+            carries: vec![false; poly_length],
+            decomposed_poly: vec![T::ZERO; poly_length],
+            decomposed_fourier: vec![Complex64::new(0.0, 0.0); fourier_length],
+            fourier_accumulator: vec![Complex64::new(0.0, 0.0); total_polys * fourier_length],
+        }
+    }
+
+    /// Resizes all buffers to the given dimensions.
+    pub fn resize(&mut self, poly_length: usize, fourier_length: usize, glwe_dimension: usize) {
+        let total_polys = glwe_dimension + 1;
+        self.carries.resize(poly_length, false);
+        self.decomposed_poly.resize(poly_length, T::ZERO);
+        self.decomposed_fourier
+            .resize(fourier_length, Complex64::new(0.0, 0.0));
+        self.fourier_accumulator
+            .resize(total_polys * fourier_length, Complex64::new(0.0, 0.0));
+    }
+}

--- a/crates/primus_lattice/src/ggsw/coeff.rs
+++ b/crates/primus_lattice/src/ggsw/coeff.rs
@@ -1,0 +1,30 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glev::{GlevIter, GlevIterMut};
+
+use super::NttGgsw;
+
+/// Represents a ciphertext in the General-GSW homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::glev::Glev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct Ggsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Ggsw<S>);
+impl_bytes_conversion!(Ggsw<S>);
+impl_zero!(Ggsw<S>);
+impl_iters!(Ggsw);
+impl_iter_sub_structure!(Ggsw<S>, Glev);
+impl_basic_operation_single_modulus!(Ggsw<S>);
+impl_ntt!(Ggsw<S>, NttGgsw);

--- a/crates/primus_lattice/src/ggsw/crt.rs
+++ b/crates/primus_lattice/src/ggsw/crt.rs
@@ -1,0 +1,31 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glev::{CrtGlevIter, CrtGlevIterMut};
+
+use super::DcrtGgsw;
+
+/// Represents a ciphertext in the General-GSW homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::glev::CrtGlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct CrtGgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(CrtGgsw<S>);
+impl_bytes_conversion!(CrtGgsw<S>);
+impl_zero!(CrtGgsw<S>);
+impl_iters!(CrtGgsw);
+impl_iter_sub_structure!(CrtGgsw<S>, CrtGlev);
+impl_basic_operation_multiple_modulus!(CrtGgsw<S>);
+impl_crt_ntt!(CrtGgsw<S>, DcrtGgsw);

--- a/crates/primus_lattice/src/ggsw/dcrt.rs
+++ b/crates/primus_lattice/src/ggsw/dcrt.rs
@@ -1,0 +1,31 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glev::{DcrtGlevIter, DcrtGlevIterMut};
+
+use super::CrtGgsw;
+
+/// Represents a ciphertext in the Ring-GSW (Ring Learning With Errors) homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::glev::DcrtGlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct DcrtGgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(DcrtGgsw<S>);
+impl_bytes_conversion!(DcrtGgsw<S>);
+impl_zero!(DcrtGgsw<S>);
+impl_iters!(DcrtGgsw);
+impl_iter_sub_structure!(DcrtGgsw<S>, DcrtGlev);
+impl_basic_operation_multiple_modulus!(DcrtGgsw<S>);
+impl_crt_intt!(DcrtGgsw<S>, CrtGgsw);

--- a/crates/primus_lattice/src/ggsw/dcrt.rs
+++ b/crates/primus_lattice/src/ggsw/dcrt.rs
@@ -9,7 +9,7 @@ use crate::glev::{DcrtGlevIter, DcrtGlevIterMut};
 
 use super::CrtGgsw;
 
-/// Represents a ciphertext in the Ring-GSW (Ring Learning With Errors) homomorphic encryption scheme.
+/// Represents a ciphertext in the General-GSW homomorphic encryption scheme.
 ///
 /// ## Structure of the `data`
 ///

--- a/crates/primus_lattice/src/ggsw/fourier.rs
+++ b/crates/primus_lattice/src/ggsw/fourier.rs
@@ -1,0 +1,29 @@
+use primus_data::RawData;
+
+use num_complex::Complex64;
+use crate::glev::fourier::{FourierGlevIter, FourierGlevIterMut};
+
+/// Fourier-domain GGSW ciphertext — matrix of [`FourierGlev`], one per row.
+///
+/// ## Layout
+///
+/// ```text
+/// |--row_0--| ... |--row_k--|
+/// ```
+///
+/// Each row is a [`FourierGlev`](crate::glev::fourier::FourierGlev) of length
+/// `fourier_glev_len`.
+/// Total data length: `(k + 1) * fourier_glev_len`.
+#[derive(Clone)]
+pub struct FourierGgsw<S>(pub S)
+where
+    S: RawData<Elem = Complex64>;
+
+impl_fourier_iters!(FourierGgsw);
+impl_fourier_core!(FourierGgsw);
+impl_fourier_iter_sub!(
+    FourierGgsw,
+    FourierGlevIter,
+    FourierGlevIterMut,
+    glev
+);

--- a/crates/primus_lattice/src/ggsw/fourier.rs
+++ b/crates/primus_lattice/src/ggsw/fourier.rs
@@ -1,7 +1,7 @@
 use primus_data::RawData;
 
-use num_complex::Complex64;
 use crate::glev::fourier::{FourierGlevIter, FourierGlevIterMut};
+use num_complex::Complex64;
 
 /// Fourier-domain GGSW ciphertext — matrix of [`FourierGlev`], one per row.
 ///
@@ -21,9 +21,4 @@ where
 
 impl_fourier_iters!(FourierGgsw);
 impl_fourier_core!(FourierGgsw);
-impl_fourier_iter_sub!(
-    FourierGgsw,
-    FourierGlevIter,
-    FourierGlevIterMut,
-    glev
-);
+impl_fourier_iter_sub!(FourierGgsw, FourierGlevIter, FourierGlevIterMut, glev);

--- a/crates/primus_lattice/src/ggsw/fourier.rs
+++ b/crates/primus_lattice/src/ggsw/fourier.rs
@@ -3,7 +3,8 @@ use primus_data::RawData;
 use crate::glev::fourier::{FourierGlevIter, FourierGlevIterMut};
 use num_complex::Complex64;
 
-/// Fourier-domain GGSW ciphertext — matrix of [`FourierGlev`], one per row.
+/// Fourier-domain GGSW ciphertext — matrix of
+/// [`crate::glev::fourier::FourierGlev`], one per row.
 ///
 /// ## Layout
 ///

--- a/crates/primus_lattice/src/ggsw/mod.rs
+++ b/crates/primus_lattice/src/ggsw/mod.rs
@@ -3,9 +3,11 @@ mod ntt;
 
 mod crt;
 mod dcrt;
+pub mod fourier;
 
 pub use coeff::{Ggsw, GgswIter, GgswIterMut};
 pub use ntt::{NttGgsw, NttGgswIter, NttGgswIterMut};
 
 pub use crt::{CrtGgsw, CrtGgswIter, CrtGgswIterMut};
 pub use dcrt::{DcrtGgsw, DcrtGgswIter, DcrtGgswIterMut};
+pub use fourier::{FourierGgsw, FourierGgswIter, FourierGgswIterMut, FourierGgswOwned};

--- a/crates/primus_lattice/src/ggsw/mod.rs
+++ b/crates/primus_lattice/src/ggsw/mod.rs
@@ -1,0 +1,11 @@
+mod coeff;
+mod ntt;
+
+mod crt;
+mod dcrt;
+
+pub use coeff::{Ggsw, GgswIter, GgswIterMut};
+pub use ntt::{NttGgsw, NttGgswIter, NttGgswIterMut};
+
+pub use crt::{CrtGgsw, CrtGgswIter, CrtGgswIterMut};
+pub use dcrt::{DcrtGgsw, DcrtGgswIter, DcrtGgswIterMut};

--- a/crates/primus_lattice/src/ggsw/mod.rs
+++ b/crates/primus_lattice/src/ggsw/mod.rs
@@ -3,6 +3,7 @@ mod ntt;
 
 mod crt;
 mod dcrt;
+/// Fourier-domain GGSW ciphertexts.
 pub mod fourier;
 
 pub use coeff::{Ggsw, GgswIter, GgswIterMut};

--- a/crates/primus_lattice/src/ggsw/ntt.rs
+++ b/crates/primus_lattice/src/ggsw/ntt.rs
@@ -1,0 +1,30 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glev::{NttGlevIter, NttGlevIterMut};
+
+use super::Ggsw;
+
+/// Represents a ciphertext in the General-GSW homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::glev::NttGlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct NttGgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttGgsw<S>);
+impl_bytes_conversion!(NttGgsw<S>);
+impl_zero!(NttGgsw<S>);
+impl_iters!(NttGgsw);
+impl_iter_sub_structure!(NttGgsw<S>, NttGlev);
+impl_basic_operation_single_modulus!(NttGgsw<S>);
+impl_intt!(NttGgsw<S>, Ggsw);

--- a/crates/primus_lattice/src/glev/coeff.rs
+++ b/crates/primus_lattice/src/glev/coeff.rs
@@ -1,0 +1,31 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glwe::{GlweIter, GlweIterMut};
+
+use super::NttGlev;
+
+/// A representation of Module Learning with Errors (MLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::glwe::Glwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct Glev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Glev<S>);
+impl_bytes_conversion!(Glev<S>);
+impl_zero!(Glev<S>);
+impl_iters!(Glev);
+impl_iter_sub_structure!(Glev<S>, Glwe);
+impl_basic_operation_single_modulus!(Glev<S>);
+impl_ntt!(Glev<S>, NttGlev);

--- a/crates/primus_lattice/src/glev/crt.rs
+++ b/crates/primus_lattice/src/glev/crt.rs
@@ -1,0 +1,32 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glwe::{CrtGlweIter, CrtGlweIterMut};
+
+use super::DcrtGlev;
+
+/// A representation of Module Learning with Errors (MLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::glwe::CrtGlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct CrtGlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(CrtGlev<S>);
+impl_bytes_conversion!(CrtGlev<S>);
+impl_zero!(CrtGlev<S>);
+impl_iters!(CrtGlev);
+impl_iter_sub_structure!(CrtGlev<S>, CrtGlwe);
+impl_basic_operation_multiple_modulus!(CrtGlev<S>);
+impl_crt_ntt!(CrtGlev<S>, DcrtGlev);

--- a/crates/primus_lattice/src/glev/dcrt.rs
+++ b/crates/primus_lattice/src/glev/dcrt.rs
@@ -1,0 +1,175 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_decompose::big_integer::BigUintApproxSignedBasis;
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::{ArrayBase, BigUintPolynomial, CrtPolynomial, DcrtPolynomial};
+use primus_reduce::FieldContext;
+use primus_rns::RNSBase;
+
+use crate::{
+    context::{DcrtGlevContext, DcrtGlevContextRefMut},
+    glwe::{DcrtGlwe, DcrtGlweIter, DcrtGlweIterMut},
+};
+
+use super::CrtGlev;
+
+/// A representation of Module Learning with Errors (MLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::glwe::DcrtGlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct DcrtGlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(DcrtGlev<S>);
+impl_bytes_conversion!(DcrtGlev<S>);
+impl_zero!(DcrtGlev<S>);
+impl_iters!(DcrtGlev);
+impl_iter_sub_structure!(DcrtGlev<S>, DcrtGlwe);
+impl_basic_operation_multiple_modulus!(DcrtGlev<S>);
+impl_crt_intt!(DcrtGlev<S>, CrtGlev);
+
+impl<S, T> DcrtGlev<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    pub fn mul_crt_poly_to<M, Table, A, B>(
+        &self,
+        crt_poly: &CrtPolynomial<A>,
+        result: &mut DcrtGlwe<B>,
+        basis: &BigUintApproxSignedBasis<T>,
+        table: &Table,
+        rns_base: &RNSBase<T, M>,
+        context: &mut DcrtGlevContext<T>,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_length = table.poly_length();
+        let big_uint_value_len = rns_base.big_uint_value_len();
+        let basis_value = basis.basis_value();
+        let moduli = rns_base.moduli();
+        let dcrt_glwe_len = result.0.len();
+
+        let DcrtGlevContextRefMut {
+            adjust_big_uint_values,
+            decomposed_unsigned_values,
+            carries,
+            multi_residues,
+            compose_buffer,
+        } = context.as_mut();
+
+        rns_base.compose_multiple_values_to(
+            crt_poly.as_ref(),
+            adjust_big_uint_values,
+            poly_length,
+            compose_buffer,
+        );
+
+        basis.init_value_carry_slice_inplace(adjust_big_uint_values, carries, big_uint_value_len);
+
+        result.set_zero();
+
+        self.iter_dcrt_glwe(dcrt_glwe_len)
+            .zip(basis.decomposer_iter())
+            .for_each(|(dcrt_glwe, once_decomposer)| {
+                once_decomposer.unsigned_decompose_slice_to(
+                    adjust_big_uint_values,
+                    decomposed_unsigned_values,
+                    carries,
+                    big_uint_value_len,
+                );
+
+                rns_base.wrapping_decompose_small_values_to(
+                    decomposed_unsigned_values,
+                    multi_residues,
+                    poly_length,
+                    basis_value,
+                );
+
+                table.transform_slice(multi_residues);
+
+                result.add_dcrt_glwe_mul_dcrt_polynomial_assign(
+                    &dcrt_glwe,
+                    &DcrtPolynomial(&*multi_residues),
+                    poly_length,
+                    moduli,
+                );
+            });
+    }
+
+    pub fn mul_big_uint_poly_to<M, Table, A, B>(
+        &self,
+        big_uint_poly: &BigUintPolynomial<A>,
+        result: &mut DcrtGlwe<B>,
+        basis: &BigUintApproxSignedBasis<T>,
+        table: &Table,
+        rns_base: &RNSBase<T, M>,
+        context: &mut DcrtGlevContext<T>,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_length = table.poly_length();
+        let big_uint_value_len = rns_base.big_uint_value_len();
+        let dcrt_glwe_len = result.0.len();
+        let basis_value = basis.basis_value();
+        let moduli = rns_base.moduli();
+
+        let DcrtGlevContextRefMut {
+            adjust_big_uint_values,
+            decomposed_unsigned_values,
+            carries,
+            multi_residues,
+            compose_buffer: _,
+        } = context.as_mut();
+
+        basis.init_value_carry_slice_to(
+            big_uint_poly.as_slice(),
+            adjust_big_uint_values,
+            carries,
+            big_uint_value_len,
+        );
+
+        result.set_zero();
+
+        self.iter_dcrt_glwe(dcrt_glwe_len)
+            .zip(basis.decomposer_iter())
+            .for_each(|(dcrt_glwe, once_decomposer)| {
+                once_decomposer.unsigned_decompose_slice_to(
+                    adjust_big_uint_values,
+                    decomposed_unsigned_values,
+                    carries,
+                    big_uint_value_len,
+                );
+
+                rns_base.wrapping_decompose_small_values_to(
+                    decomposed_unsigned_values,
+                    multi_residues,
+                    poly_length,
+                    basis_value,
+                );
+
+                table.transform_slice(multi_residues);
+
+                result.add_dcrt_glwe_mul_dcrt_polynomial_assign(
+                    &dcrt_glwe,
+                    &DcrtPolynomial(&*multi_residues),
+                    poly_length,
+                    moduli,
+                );
+            });
+    }
+}

--- a/crates/primus_lattice/src/glev/dcrt.rs
+++ b/crates/primus_lattice/src/glev/dcrt.rs
@@ -41,6 +41,7 @@ where
     S: RawData<Elem = T> + Data,
     T: FheUint,
 {
+    /// Multiplies this DCRT GLEV with a CRT-domain polynomial, storing the result into `result`.
     pub fn mul_crt_poly_to<M, Table, A, B>(
         &self,
         crt_poly: &CrtPolynomial<A>,
@@ -108,6 +109,7 @@ where
             });
     }
 
+    /// Multiplies this DCRT GLEV with a BigUint-domain polynomial, storing the result into `result`.
     pub fn mul_big_uint_poly_to<M, Table, A, B>(
         &self,
         big_uint_poly: &BigUintPolynomial<A>,

--- a/crates/primus_lattice/src/glev/fourier.rs
+++ b/crates/primus_lattice/src/glev/fourier.rs
@@ -1,7 +1,7 @@
 use primus_data::RawData;
 
-use num_complex::Complex64;
 use crate::glwe::fourier::{FourierGlweIter, FourierGlweIterMut};
+use num_complex::Complex64;
 
 /// Fourier-domain GLev ciphertext — list of [`FourierGlwe`] per decomposition level.
 ///
@@ -21,9 +21,4 @@ where
 
 impl_fourier_iters!(FourierGlev);
 impl_fourier_core!(FourierGlev);
-impl_fourier_iter_sub!(
-    FourierGlev,
-    FourierGlweIter,
-    FourierGlweIterMut,
-    glwe
-);
+impl_fourier_iter_sub!(FourierGlev, FourierGlweIter, FourierGlweIterMut, glwe);

--- a/crates/primus_lattice/src/glev/fourier.rs
+++ b/crates/primus_lattice/src/glev/fourier.rs
@@ -1,0 +1,29 @@
+use primus_data::RawData;
+
+use num_complex::Complex64;
+use crate::glwe::fourier::{FourierGlweIter, FourierGlweIterMut};
+
+/// Fourier-domain GLev ciphertext — list of [`FourierGlwe`] per decomposition level.
+///
+/// ## Layout
+///
+/// ```text
+/// |--glwe_level_0--| ... |--glwe_level_{level-1}--|
+/// ```
+///
+/// Each level is a [`FourierGlwe`](crate::glwe::fourier::FourierGlwe) of length
+/// `fourier_glwe_len`.
+/// Total data length: `level * fourier_glwe_len`.
+#[derive(Clone)]
+pub struct FourierGlev<S>(pub S)
+where
+    S: RawData<Elem = Complex64>;
+
+impl_fourier_iters!(FourierGlev);
+impl_fourier_core!(FourierGlev);
+impl_fourier_iter_sub!(
+    FourierGlev,
+    FourierGlweIter,
+    FourierGlweIterMut,
+    glwe
+);

--- a/crates/primus_lattice/src/glev/fourier.rs
+++ b/crates/primus_lattice/src/glev/fourier.rs
@@ -3,7 +3,8 @@ use primus_data::RawData;
 use crate::glwe::fourier::{FourierGlweIter, FourierGlweIterMut};
 use num_complex::Complex64;
 
-/// Fourier-domain GLev ciphertext — list of [`FourierGlwe`] per decomposition level.
+/// Fourier-domain GLev ciphertext — list of
+/// [`crate::glwe::fourier::FourierGlwe`] per decomposition level.
 ///
 /// ## Layout
 ///

--- a/crates/primus_lattice/src/glev/mod.rs
+++ b/crates/primus_lattice/src/glev/mod.rs
@@ -3,6 +3,7 @@ mod ntt;
 
 mod crt;
 mod dcrt;
+/// Fourier-domain GLev ciphertexts.
 pub mod fourier;
 
 pub use coeff::{Glev, GlevIter, GlevIterMut};

--- a/crates/primus_lattice/src/glev/mod.rs
+++ b/crates/primus_lattice/src/glev/mod.rs
@@ -3,9 +3,11 @@ mod ntt;
 
 mod crt;
 mod dcrt;
+pub mod fourier;
 
 pub use coeff::{Glev, GlevIter, GlevIterMut};
 pub use ntt::{NttGlev, NttGlevIter, NttGlevIterMut};
 
 pub use crt::{CrtGlev, CrtGlevIter, CrtGlevIterMut};
 pub use dcrt::{DcrtGlev, DcrtGlevIter, DcrtGlevIterMut};
+pub use fourier::{FourierGlev, FourierGlevIter, FourierGlevIterMut, FourierGlevOwned};

--- a/crates/primus_lattice/src/glev/mod.rs
+++ b/crates/primus_lattice/src/glev/mod.rs
@@ -1,0 +1,11 @@
+mod coeff;
+mod ntt;
+
+mod crt;
+mod dcrt;
+
+pub use coeff::{Glev, GlevIter, GlevIterMut};
+pub use ntt::{NttGlev, NttGlevIter, NttGlevIterMut};
+
+pub use crt::{CrtGlev, CrtGlevIter, CrtGlevIterMut};
+pub use dcrt::{DcrtGlev, DcrtGlevIter, DcrtGlevIterMut};

--- a/crates/primus_lattice/src/glev/ntt.rs
+++ b/crates/primus_lattice/src/glev/ntt.rs
@@ -1,0 +1,31 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::glwe::{NttGlweIter, NttGlweIterMut};
+
+use super::Glev;
+
+/// A representation of Module Learning with Errors (MLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::glwe::NttGlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct NttGlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttGlev<S>);
+impl_bytes_conversion!(NttGlev<S>);
+impl_zero!(NttGlev<S>);
+impl_iters!(NttGlev);
+impl_iter_sub_structure!(NttGlev<S>, NttGlwe);
+impl_basic_operation_single_modulus!(NttGlev<S>);
+impl_intt!(NttGlev<S>, Glev);

--- a/crates/primus_lattice/src/glwe/big_uint.rs
+++ b/crates/primus_lattice/src/glwe/big_uint.rs
@@ -1,0 +1,87 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_poly::{BigUintPolynomialIter, BigUintPolynomialIterMut};
+use primus_reduce::FieldContext;
+use primus_rns::RNSBase;
+
+use super::CrtGlwe;
+
+/// A cryptographic structure for Module(General) Learning with Errors (MLWE, GLWE).
+///
+/// ## Structure of the `data`
+///
+/// |--a1--|....|--ak--|--b--|
+///
+/// where `a1`...`ak` and `b` are [`primus_poly::BigUintPolynomial`] with same poly length, `k` is the dimension.
+#[derive(Clone)]
+pub struct BigUintGlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(BigUintGlwe<S>);
+impl_bytes_conversion!(BigUintGlwe<S>);
+impl_zero!(BigUintGlwe<S>);
+impl_iters!(BigUintGlwe);
+impl_iter_sub_structure!(BigUintGlwe<S>, BigUintPolynomial, big_uint_poly);
+
+impl<S, T> BigUintGlwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    #[inline]
+    pub fn compose_assign<A, M>(
+        &mut self,
+        crt_glwe: &CrtGlwe<A>,
+        poly_length: usize,
+        crt_poly_len: usize,
+        rns_base: &RNSBase<T, M>,
+        compose_buffer: &mut [T],
+    ) where
+        A: RawData<Elem = T> + Data,
+        M: FieldContext<T>,
+    {
+        let big_uint_value_len = rns_base.big_uint_value_len();
+        let big_uint_poly_len = poly_length * big_uint_value_len;
+
+        self.iter_big_uint_poly_mut(big_uint_poly_len)
+            .zip(crt_glwe.iter_crt_poly(crt_poly_len))
+            .for_each(|(mut big_uint_poly, crt_poly)| {
+                rns_base.compose_polynomial_to(
+                    &crt_poly,
+                    &mut big_uint_poly,
+                    poly_length,
+                    compose_buffer,
+                );
+            });
+    }
+}
+
+impl<S, T> BigUintGlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Decomposes `self`.
+    #[inline]
+    pub fn decompose_to<A, M>(
+        &self,
+        result: &mut CrtGlwe<A>,
+        poly_length: usize,
+        crt_poly_len: usize,
+        rns_base: &RNSBase<T, M>,
+    ) where
+        A: RawData<Elem = T> + DataMut,
+        M: FieldContext<T>,
+    {
+        let big_uint_value_len = rns_base.big_uint_value_len();
+        let big_uint_poly_len = poly_length * big_uint_value_len;
+
+        self.iter_big_uint_poly(big_uint_poly_len)
+            .zip(result.iter_crt_poly_mut(crt_poly_len))
+            .for_each(|(big_uint_poly, mut crt_poly)| {
+                rns_base.decompose_polynomial_to(&big_uint_poly, &mut crt_poly, poly_length);
+            });
+    }
+}

--- a/crates/primus_lattice/src/glwe/big_uint.rs
+++ b/crates/primus_lattice/src/glwe/big_uint.rs
@@ -30,6 +30,7 @@ where
     S: RawData<Elem = T> + DataMut,
     T: FheUint,
 {
+    /// Composes the CRT representation in `crt_glwe` into this BigUint GLWE.
     #[inline]
     pub fn compose_assign<A, M>(
         &mut self,

--- a/crates/primus_lattice/src/glwe/coeff.rs
+++ b/crates/primus_lattice/src/glwe/coeff.rs
@@ -1,0 +1,59 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial, PolynomialIter, PolynomialIterMut};
+use primus_reduce::FieldContext;
+
+use super::NttGlwe;
+
+/// A cryptographic structure for Module(General) Learning with Errors (MLWE, GLWE).
+///
+/// ## Structure of the `data`
+///
+/// |--a1--|....|--ak--|--b--|
+///
+/// where `a1`...`ak` and `b` are [`primus_poly::Polynomial`] with same poly length, `k` is the dimension.
+#[derive(Clone)]
+pub struct Glwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Glwe<S>);
+impl_bytes_conversion!(Glwe<S>);
+impl_zero!(Glwe<S>);
+impl_iters!(Glwe);
+impl_iter_sub_structure!(Glwe<S>, Polynomial, poly);
+impl_basic_operation_single_modulus!(Glwe<S>);
+impl_ntt!(Glwe<S>, NttGlwe);
+
+impl<S, T> Glwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Performs a multiplication on the `self` [`Glwe<S>`] with another `ntt_poly` [`NttPolynomial<A>`],
+    /// store the result into `result` [`NttGlwe<B>`].
+    #[inline]
+    pub fn mul_ntt_polynomial_to<M, Table, A, B>(
+        &self,
+        ntt_poly: &NttPolynomial<A>,
+        result: &mut NttGlwe<B>,
+        modulus: M,
+        ntt_table: &Table,
+    ) where
+        M: FieldContext<T>,
+        Table: NttTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let ntt_poly_len = ntt_table.poly_length();
+
+        result.0.copy_from_slice(self.as_ref());
+
+        result.iter_ntt_poly_mut(ntt_poly_len).for_each(|mut poly| {
+            ntt_table.transform_slice(poly.0);
+            poly.mul_assign(ntt_poly, modulus);
+        });
+    }
+}

--- a/crates/primus_lattice/src/glwe/crt.rs
+++ b/crates/primus_lattice/src/glwe/crt.rs
@@ -1,0 +1,224 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_decompose::big_integer::BigUintApproxSignedBasis;
+use primus_factor::FactorSliceOps;
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::{
+    ArrayBase, CrtPolynomial, CrtPolynomialIter, CrtPolynomialIterMut, DcrtPolynomial,
+};
+use primus_reduce::FieldContext;
+use primus_rns::RNSBase;
+
+use crate::{context::DcrtGlevContext, ggsw::DcrtGgsw};
+
+use super::DcrtGlwe;
+
+/// A cryptographic structure for Module(General) Learning with Errors (MLWE, GLWE).
+///
+/// ## Structure of the `data`
+///
+/// |--a1--|....|--ak--|--b--|
+///
+/// where `a1`...`ak` and `b` are [`primus_poly::CrtPolynomial`] with same poly length and moduli count, `k` is the dimension.
+#[derive(Clone)]
+pub struct CrtGlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(CrtGlwe<S>);
+impl_bytes_conversion!(CrtGlwe<S>);
+impl_zero!(CrtGlwe<S>);
+impl_iters!(CrtGlwe);
+impl_iter_sub_structure!(CrtGlwe<S>, CrtPolynomial, crt_poly);
+impl_basic_operation_multiple_modulus!(CrtGlwe<S>);
+impl_crt_ntt!(CrtGlwe<S>, DcrtGlwe);
+
+impl<S, T> CrtGlwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Extracts mutable slice of `a` and `b` of this [`CrtGlwe<S>`].
+    #[inline]
+    pub fn a_b_mut_slices(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+        self.0.split_at_mut(mid)
+    }
+
+    /// Extracts mutable `a` and `b` of this [`CrtGlwe<S>`].
+    #[inline]
+    pub fn a_b_mut(
+        &mut self,
+        mid: usize,
+    ) -> (CrtPolynomialIterMut<'_, T>, CrtPolynomial<&mut [T]>) {
+        let (a, b) = self.0.split_at_mut(mid);
+        (CrtPolynomialIterMut::new(a, b.len()), CrtPolynomial(b))
+    }
+
+    pub fn mul_scalar_assign<M>(
+        &mut self,
+        scalar_residue: &[T],
+        poly_length: usize,
+        crt_poly_len: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+    {
+        self.iter_crt_poly_mut(crt_poly_len)
+            .for_each(|mut crt_poly| {
+                crt_poly.mul_scalar_assign(scalar_residue, poly_length, moduli);
+            });
+    }
+
+    /// Perform `self = self * X^r`.
+    pub fn mul_monic_monomial_assign<M>(
+        &mut self,
+        r: usize,
+        poly_length: usize,
+        crt_poly_len: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+    {
+        if r < poly_length {
+            let rotate = |poly: &mut [T], modulus: M| {
+                poly.rotate_right(r);
+                modulus.reduce_neg_slice_assign(&mut poly[0..r]);
+            };
+
+            self.iter_crt_poly_mut(crt_poly_len)
+                .for_each(|mut crt_poly| {
+                    crt_poly
+                        .iter_each_modulus_mut(poly_length)
+                        .zip(moduli)
+                        .for_each(|(poly, &modulus)| rotate(poly, modulus));
+                });
+        } else {
+            debug_assert!(r < poly_length * 2);
+            let r = r - poly_length;
+            let rotate = |poly: &mut [T], modulus: M| {
+                poly.rotate_right(r);
+                modulus.reduce_neg_slice_assign(&mut poly[r..]);
+            };
+
+            self.iter_crt_poly_mut(crt_poly_len)
+                .for_each(|mut crt_poly| {
+                    crt_poly
+                        .iter_each_modulus_mut(poly_length)
+                        .zip(moduli)
+                        .for_each(|(poly, &modulus)| rotate(poly, modulus));
+                });
+        }
+    }
+}
+
+impl<S, T> CrtGlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Extracts slice of `a` and `b` of this [`CrtGlwe<S>`].
+    #[inline]
+    pub fn a_b_slices(&self, mid: usize) -> (&[T], &[T]) {
+        self.0.split_at(mid)
+    }
+
+    /// Extracts slice of `a` and `b` of this [`CrtGlwe<S>`].
+    #[inline]
+    pub fn a_b(&self, mid: usize) -> (CrtPolynomialIter<'_, T>, CrtPolynomial<&[T]>) {
+        let (a, b) = self.0.split_at(mid);
+        (CrtPolynomialIter::new(a, b.len()), CrtPolynomial(b))
+    }
+
+    pub fn mul_scalar_to<M, A>(
+        &self,
+        scalar_residue: &[T],
+        result: &mut CrtGlwe<A>,
+        poly_length: usize,
+        crt_poly_len: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + DataMut,
+    {
+        self.iter_crt_poly(crt_poly_len)
+            .zip(result.iter_crt_poly_mut(crt_poly_len))
+            .for_each(|(in_crt_poly, mut out_crt_poly)| {
+                in_crt_poly.mul_scalar_to(scalar_residue, &mut out_crt_poly, poly_length, moduli);
+            });
+    }
+
+    pub fn mul_factor_to<F, A>(
+        &self,
+        scalar: &[F],
+        result: &mut CrtGlwe<A>,
+        poly_length: usize,
+        crt_poly_len: usize,
+        moduli: &[T],
+    ) where
+        F: Copy + FactorSliceOps<T>,
+        A: RawData<Elem = T> + DataMut,
+    {
+        self.iter_crt_poly(crt_poly_len)
+            .zip(result.iter_crt_poly_mut(crt_poly_len))
+            .for_each(|(in_crt_poly, mut out_crt_poly)| {
+                in_crt_poly.mul_factor_to(scalar, &mut out_crt_poly, poly_length, moduli);
+            });
+    }
+
+    /// Performs a multiplication on the `self` [`CrtGlwe<S>`] with another `dcrt_poly` [`DcrtPolynomial<A>`],
+    /// store the result into `result` [`DcrtGlwe<T>`].
+    #[inline]
+    pub fn mul_dcrt_polynomial_to<M, Table, A, B>(
+        &self,
+        dcrt_poly: &DcrtPolynomial<A>,
+        result: &mut DcrtGlwe<B>,
+        moduli: &[M],
+        table: &Table,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_length = table.poly_length();
+        let dcrt_poly_len = table.crt_poly_length();
+
+        result.0.copy_from_slice(self.as_ref());
+
+        result.iter_dcrt_poly_mut(dcrt_poly_len).for_each(|mut x| {
+            table.transform_slice(x.0);
+            x.mul_assign(dcrt_poly, poly_length, moduli);
+        });
+    }
+
+    pub fn mul_dcrt_ggsw_to<M, Table, A, B>(
+        &self,
+        dcrt_ggsw: &DcrtGgsw<A>,
+        result: &mut DcrtGlwe<B>,
+        basis: &BigUintApproxSignedBasis<T>,
+        table: &Table,
+        rns_base: &RNSBase<T, M>,
+        context: &mut DcrtGlevContext<T>,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let crt_poly_len = table.crt_poly_length();
+        let dcrt_glev_len = basis.decompose_length() * self.as_ref().len();
+
+        result.set_zero();
+
+        dcrt_ggsw
+            .iter_dcrt_glev(dcrt_glev_len)
+            .zip(self.iter_crt_poly(crt_poly_len))
+            .for_each(|(dcrt_glev, crt_poly)| {
+                result.add_dcrt_glev_mul_crt_poly_assign(
+                    &dcrt_glev, &crt_poly, basis, table, rns_base, context,
+                );
+            });
+    }
+}

--- a/crates/primus_lattice/src/glwe/crt.rs
+++ b/crates/primus_lattice/src/glwe/crt.rs
@@ -56,6 +56,7 @@ where
         (CrtPolynomialIterMut::new(a, b.len()), CrtPolynomial(b))
     }
 
+    /// Multiplies each CRT polynomial component by `scalar_residue` in place.
     pub fn mul_scalar_assign<M>(
         &mut self,
         scalar_residue: &[T],
@@ -131,6 +132,7 @@ where
         (CrtPolynomialIter::new(a, b.len()), CrtPolynomial(b))
     }
 
+    /// Multiplies this CRT GLWE by a scalar residue and writes the result into `result`.
     pub fn mul_scalar_to<M, A>(
         &self,
         scalar_residue: &[T],
@@ -149,6 +151,7 @@ where
             });
     }
 
+    /// Multiplies this CRT GLWE by a Shoup factor and writes the result into `result`.
     pub fn mul_factor_to<F, A>(
         &self,
         scalar: &[F],
@@ -193,6 +196,7 @@ where
         });
     }
 
+    /// Multiplies this CRT GLWE by a DCRT GGSW ciphertext, storing the result into `result`.
     pub fn mul_dcrt_ggsw_to<M, Table, A, B>(
         &self,
         dcrt_ggsw: &DcrtGgsw<A>,

--- a/crates/primus_lattice/src/glwe/dcrt.rs
+++ b/crates/primus_lattice/src/glwe/dcrt.rs
@@ -60,6 +60,7 @@ where
         (DcrtPolynomialIterMut::new(a, b.len()), DcrtPolynomial(b))
     }
 
+    /// Negates each DCRT polynomial component in place.
     pub fn neg_assign<M>(&mut self, dcrt_poly_len: usize, poly_length: usize, moduli: &[M])
     where
         M: FieldContext<T>,
@@ -70,6 +71,7 @@ where
             });
     }
 
+    /// Multiplies each DCRT polynomial component by `scalar_residue` in place.
     pub fn mul_scalar_assign<M>(
         &mut self,
         scalar_residue: &[T],
@@ -102,6 +104,7 @@ where
             });
     }
 
+    /// Performs `self += dcrt_glwe * dcrt_poly` in place.
     pub fn add_dcrt_glwe_mul_dcrt_polynomial_assign<M, A, B>(
         &mut self,
         dcrt_glwe: &DcrtGlwe<A>,
@@ -171,6 +174,7 @@ where
             });
     }
 
+    /// Performs `self += dcrt_glev * crt_poly` using the given decomposition basis and NTT table.
     pub fn add_dcrt_glev_mul_crt_poly_assign<M, Table, A, B>(
         &mut self,
         dcrt_glev: &DcrtGlev<A>,
@@ -250,6 +254,7 @@ where
             });
     }
 
+    /// Performs `self += dcrt_glev * big_uint_poly` using the given decomposition basis and NTT table.
     pub fn add_dcrt_glev_mul_big_uint_poly_assign<M, Table, A, B>(
         &mut self,
         dcrt_glev: &DcrtGlev<A>,
@@ -347,6 +352,7 @@ where
         (DcrtPolynomialIter::new(a, b.len()), DcrtPolynomial(b))
     }
 
+    /// Multiplies this DCRT GLWE by a Shoup factor and writes the result into `result`.
     pub fn mul_factor_to<F, A>(
         &self,
         scalar: &[F],

--- a/crates/primus_lattice/src/glwe/dcrt.rs
+++ b/crates/primus_lattice/src/glwe/dcrt.rs
@@ -1,0 +1,390 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_decompose::big_integer::BigUintApproxSignedBasis;
+use primus_factor::{FactorSliceOps, ShoupFactor};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::{
+    ArrayBase, BigUintPolynomial, CrtPolynomial, DcrtPolynomial, DcrtPolynomialIter,
+    DcrtPolynomialIterMut,
+};
+use primus_reduce::FieldContext;
+use primus_rns::RNSBase;
+
+use crate::{
+    context::{DcrtGlevContext, DcrtGlevContextRefMut},
+    glev::DcrtGlev,
+};
+
+use super::CrtGlwe;
+
+/// A cryptographic structure for Module(General) Learning with Errors (MLWE, GLWE).
+///
+/// ## Structure of the `data`
+///
+/// |--a1--|....|--ak--|--b--|
+///
+/// where `a1`...`ak` and `b` are [`DcrtPolynomial`] with same poly length and moduli count, `k` is the dimension.
+#[derive(Clone)]
+pub struct DcrtGlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(DcrtGlwe<S>);
+impl_bytes_conversion!(DcrtGlwe<S>);
+impl_zero!(DcrtGlwe<S>);
+impl_iters!(DcrtGlwe);
+impl_iter_sub_structure!(DcrtGlwe<S>, DcrtPolynomial, dcrt_poly);
+impl_basic_operation_multiple_modulus!(DcrtGlwe<S>);
+impl_crt_intt!(DcrtGlwe<S>, CrtGlwe);
+
+impl<S, T> DcrtGlwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Extracts mutable slice of `a` and `b` of this [`DcrtGlwe<S>`].
+    #[inline]
+    pub fn a_b_mut_slices(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+        self.as_mut().split_at_mut(mid)
+    }
+
+    /// Extracts mutable `a` and `b` of this [`DcrtGlwe<S>`].
+    #[inline]
+    pub fn a_b_mut(
+        &mut self,
+        mid: usize,
+    ) -> (DcrtPolynomialIterMut<'_, T>, DcrtPolynomial<&mut [T]>) {
+        let (a, b) = self.as_mut().split_at_mut(mid);
+        (DcrtPolynomialIterMut::new(a, b.len()), DcrtPolynomial(b))
+    }
+
+    pub fn neg_assign<M>(&mut self, dcrt_poly_len: usize, poly_length: usize, moduli: &[M])
+    where
+        M: FieldContext<T>,
+    {
+        self.iter_dcrt_poly_mut(dcrt_poly_len)
+            .for_each(|mut dcrt_poly| {
+                dcrt_poly.neg_assign(poly_length, moduli);
+            });
+    }
+
+    pub fn mul_scalar_assign<M>(
+        &mut self,
+        scalar_residue: &[T],
+        poly_length: usize,
+        dcrt_poly_len: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+    {
+        self.iter_dcrt_poly_mut(dcrt_poly_len)
+            .for_each(|mut dcrt_poly| {
+                dcrt_poly.mul_scalar_assign(scalar_residue, poly_length, moduli);
+            });
+    }
+
+    /// Performs `self *= scalar` according to `moduli`.
+    #[inline]
+    pub fn mul_factor_assign<F>(
+        &mut self,
+        scalar: &[F],
+        poly_length: usize,
+        dcrt_poly_len: usize,
+        moduli: &[T],
+    ) where
+        F: Copy + FactorSliceOps<T>,
+    {
+        self.iter_dcrt_poly_mut(dcrt_poly_len)
+            .for_each(|mut dcrt_poly| {
+                dcrt_poly.mul_factor_assign(scalar, poly_length, moduli);
+            });
+    }
+
+    pub fn add_dcrt_glwe_mul_dcrt_polynomial_assign<M, A, B>(
+        &mut self,
+        dcrt_glwe: &DcrtGlwe<A>,
+        dcrt_poly: &DcrtPolynomial<B>,
+        poly_length: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + Data,
+    {
+        let dcrt_poly_len = dcrt_poly.dcrt_poly_length();
+
+        self.iter_dcrt_poly_mut(dcrt_poly_len)
+            .zip(dcrt_glwe.iter_dcrt_poly(dcrt_poly_len))
+            .for_each(|(mut x, y)| {
+                x.add_mul_assign(&y, dcrt_poly, poly_length, moduli);
+            });
+    }
+
+    /// Inverse butterfly with monomial multiply.
+    /// `(self, result) = (self + rhs, (self_orig - rhs) * dcrt_poly)`
+    pub fn butterfly_mul_dcrt_polynomial_to<M, A, B, C>(
+        &mut self,
+        rhs: &DcrtGlwe<A>,
+        dcrt_poly: &DcrtPolynomial<B>,
+        result: &mut DcrtGlwe<C>,
+        poly_length: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + Data,
+        C: RawData<Elem = T> + DataMut,
+    {
+        let dcrt_poly_len = dcrt_poly.dcrt_poly_length();
+        self.iter_dcrt_poly_mut(dcrt_poly_len)
+            .zip(rhs.iter_dcrt_poly(dcrt_poly_len))
+            .zip(result.iter_dcrt_poly_mut(dcrt_poly_len))
+            .for_each(|((mut a, s), mut b)| {
+                a.butterfly_mul_to(&s, dcrt_poly, &mut b, poly_length, moduli);
+            });
+    }
+
+    /// Inverse butterfly with a Shoup-factor DCRT polynomial.
+    /// `(self, result) = (self + rhs, (self_orig - rhs) * factor_poly)`.
+    ///
+    /// `self` and `rhs` are expected in `[0, q)`. Both outputs are written
+    /// back in `[0, q)`.
+    pub fn butterfly_mul_factor_to<A, C>(
+        &mut self,
+        rhs: &DcrtGlwe<A>,
+        factor_poly: &[ShoupFactor<T>],
+        result: &mut DcrtGlwe<C>,
+        poly_length: usize,
+        moduli: &[T],
+    ) where
+        A: RawData<Elem = T> + Data,
+        C: RawData<Elem = T> + DataMut,
+    {
+        let dcrt_poly_len = factor_poly.len();
+        self.iter_dcrt_poly_mut(dcrt_poly_len)
+            .zip(rhs.iter_dcrt_poly(dcrt_poly_len))
+            .zip(result.iter_dcrt_poly_mut(dcrt_poly_len))
+            .for_each(|((mut a, s), mut b)| {
+                a.butterfly_mul_factor_to(&s, factor_poly, &mut b, poly_length, moduli);
+            });
+    }
+
+    pub fn add_dcrt_glev_mul_crt_poly_assign<M, Table, A, B>(
+        &mut self,
+        dcrt_glev: &DcrtGlev<A>,
+        crt_poly: &CrtPolynomial<B>,
+        basis: &BigUintApproxSignedBasis<T>,
+        table: &Table,
+        rns_base: &RNSBase<T, M>,
+        context: &mut DcrtGlevContext<T>,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + Data,
+    {
+        let poly_length = table.poly_length();
+        let big_uint_value_len = rns_base.big_uint_value_len();
+        let basis_value = basis.basis_value();
+
+        let moduli = rns_base.moduli();
+        let dcrt_glwe_len = self.0.len();
+
+        let DcrtGlevContextRefMut {
+            adjust_big_uint_values,
+            decomposed_unsigned_values,
+            carries,
+            multi_residues,
+            compose_buffer,
+        } = context.as_mut();
+
+        debug_assert_eq!(
+            adjust_big_uint_values.len(),
+            poly_length * big_uint_value_len
+        );
+        debug_assert_eq!(decomposed_unsigned_values.len(), poly_length);
+        debug_assert_eq!(carries.len(), poly_length);
+        debug_assert_eq!(multi_residues.len(), poly_length * moduli.len());
+        debug_assert_eq!(
+            dcrt_glev.as_ref().len(),
+            dcrt_glwe_len * basis.decompose_length()
+        );
+
+        rns_base.compose_multiple_values_to(
+            crt_poly.as_ref(),
+            adjust_big_uint_values,
+            poly_length,
+            compose_buffer,
+        );
+
+        basis.init_value_carry_slice_inplace(adjust_big_uint_values, carries, big_uint_value_len);
+
+        dcrt_glev
+            .iter_dcrt_glwe(dcrt_glwe_len)
+            .zip(basis.decomposer_iter())
+            .for_each(|(dcrt_glwe, once_decomposer)| {
+                once_decomposer.unsigned_decompose_slice_to(
+                    adjust_big_uint_values.as_ref(),
+                    decomposed_unsigned_values,
+                    carries,
+                    big_uint_value_len,
+                );
+
+                rns_base.wrapping_decompose_small_values_to(
+                    decomposed_unsigned_values.as_ref(),
+                    multi_residues,
+                    poly_length,
+                    basis_value,
+                );
+
+                table.transform_slice(multi_residues);
+
+                self.add_dcrt_glwe_mul_dcrt_polynomial_assign(
+                    &dcrt_glwe,
+                    &DcrtPolynomial(&*multi_residues),
+                    poly_length,
+                    moduli,
+                );
+            });
+    }
+
+    pub fn add_dcrt_glev_mul_big_uint_poly_assign<M, Table, A, B>(
+        &mut self,
+        dcrt_glev: &DcrtGlev<A>,
+        big_uint_poly: &BigUintPolynomial<B>,
+        basis: &BigUintApproxSignedBasis<T>,
+        table: &Table,
+        rns_base: &RNSBase<T, M>,
+        context: &mut DcrtGlevContext<T>,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + Data,
+    {
+        let poly_length = table.poly_length();
+        let big_uint_value_len = rns_base.big_uint_value_len();
+        let big_uint_poly_len = big_uint_poly.len();
+        let basis_value = basis.basis_value();
+
+        debug_assert_eq!(big_uint_poly_len, big_uint_value_len * poly_length);
+
+        let moduli = rns_base.moduli();
+        let dcrt_glwe_len = self.0.len();
+
+        context.clear();
+        let DcrtGlevContextRefMut {
+            adjust_big_uint_values,
+            decomposed_unsigned_values,
+            carries,
+            multi_residues,
+            compose_buffer: _,
+        } = context.as_mut();
+
+        debug_assert_eq!(adjust_big_uint_values.len(), big_uint_poly_len);
+        debug_assert_eq!(decomposed_unsigned_values.len(), poly_length);
+        debug_assert_eq!(carries.len(), poly_length);
+        debug_assert_eq!(multi_residues.len(), poly_length * moduli.len());
+        debug_assert_eq!(
+            dcrt_glev.as_ref().len(),
+            dcrt_glwe_len * basis.decompose_length()
+        );
+
+        basis.init_value_carry_slice_to(
+            big_uint_poly.as_slice(),
+            adjust_big_uint_values,
+            carries,
+            big_uint_value_len,
+        );
+
+        dcrt_glev
+            .iter_dcrt_glwe(dcrt_glwe_len)
+            .zip(basis.decomposer_iter())
+            .for_each(|(dcrt_glwe, once_decomposer)| {
+                once_decomposer.unsigned_decompose_slice_to(
+                    adjust_big_uint_values.as_ref(),
+                    decomposed_unsigned_values,
+                    carries,
+                    big_uint_value_len,
+                );
+
+                rns_base.wrapping_decompose_small_values_to(
+                    decomposed_unsigned_values.as_ref(),
+                    multi_residues,
+                    poly_length,
+                    basis_value,
+                );
+
+                table.transform_slice(multi_residues);
+
+                self.add_dcrt_glwe_mul_dcrt_polynomial_assign(
+                    &dcrt_glwe,
+                    &DcrtPolynomial(&*multi_residues),
+                    poly_length,
+                    moduli,
+                );
+            });
+    }
+}
+
+impl<S, T> DcrtGlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Extracts slice of `a` and `b` of this [`DcrtGlwe<S, T>`].
+    #[inline]
+    pub fn a_b_slices(&self, mid: usize) -> (&[T], &[T]) {
+        self.0.split_at(mid)
+    }
+
+    /// Extracts `a` and `b` of this [`DcrtGlwe<S, T>`].
+    #[inline]
+    pub fn a_b(&self, mid: usize) -> (DcrtPolynomialIter<'_, T>, DcrtPolynomial<&[T]>) {
+        let (a, b) = self.0.split_at(mid);
+        (DcrtPolynomialIter::new(a, b.len()), DcrtPolynomial(b))
+    }
+
+    pub fn mul_factor_to<F, A>(
+        &self,
+        scalar: &[F],
+        result: &mut DcrtGlwe<A>,
+        poly_length: usize,
+        dcrt_poly_len: usize,
+        moduli: &[T],
+    ) where
+        F: Copy + FactorSliceOps<T>,
+        A: RawData<Elem = T> + DataMut,
+    {
+        self.iter_dcrt_poly(dcrt_poly_len)
+            .zip(result.iter_dcrt_poly_mut(dcrt_poly_len))
+            .for_each(|(in_dcrt_poly, mut out_dcrt_poly)| {
+                in_dcrt_poly.mul_factor_to(scalar, &mut out_dcrt_poly, poly_length, moduli);
+            });
+    }
+
+    /// Performs a multiplication on the `self` [`DcrtGlwe<S>`] with another `dcrt_polynomial` [`DcrtPolynomial<A>`],
+    /// store the result into `result` [`DcrtGlwe<B>`].
+    #[inline]
+    pub fn mul_dcrt_polynomial_to<M, A, B>(
+        &self,
+        dcrt_poly: &DcrtPolynomial<A>,
+        result: &mut DcrtGlwe<B>,
+        poly_length: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let dcrt_poly_len = dcrt_poly.dcrt_poly_length();
+
+        self.iter_dcrt_poly(dcrt_poly_len)
+            .zip(result.iter_dcrt_poly_mut(dcrt_poly_len))
+            .for_each(|(a, mut b)| {
+                a.mul_to(dcrt_poly, &mut b, poly_length, moduli);
+            });
+    }
+}

--- a/crates/primus_lattice/src/glwe/fourier.rs
+++ b/crates/primus_lattice/src/glwe/fourier.rs
@@ -1,7 +1,7 @@
-use primus_data::RawData;
+use primus_data::{Data, RawData};
 
 use num_complex::Complex64;
-use primus_poly::{FourierPolynomialIter, FourierPolynomialIterMut};
+use primus_poly::{FourierPolynomial, FourierPolynomialIter, FourierPolynomialIterMut};
 
 /// Fourier-domain GLWE ciphertext.
 ///
@@ -53,5 +53,28 @@ where
     #[inline]
     pub fn a_b_mut_slices(&mut self, mid: usize) -> (&mut [Complex64], &mut [Complex64]) {
         self.0.split_at_mut(mid)
+    }
+
+    /// Performs `self += poly * rhs` for each component (pointwise FMA).
+    ///
+    /// This is the core operation in the TFHE external product hot loop:
+    /// the accumulator GLWE accumulates the product of a decomposed FFT
+    /// polynomial with a GGSW key GLWE.
+    #[inline]
+    pub fn add_mul_fourier_poly_assign<A, B>(
+        &mut self,
+        poly: &FourierPolynomial<A>,
+        rhs: &FourierGlwe<B>,
+    ) where
+        A: RawData<Elem = Complex64> + Data,
+        B: RawData<Elem = Complex64> + Data,
+    {
+        let flen = poly.fourier_length();
+        for (mut acc, key_poly) in self
+            .iter_fourier_poly_mut(flen)
+            .zip(rhs.iter_fourier_poly(flen))
+        {
+            acc.add_mul_assign(poly, &key_poly);
+        }
     }
 }

--- a/crates/primus_lattice/src/glwe/fourier.rs
+++ b/crates/primus_lattice/src/glwe/fourier.rs
@@ -1,0 +1,57 @@
+use primus_data::RawData;
+
+use num_complex::Complex64;
+use primus_poly::{FourierPolynomialIter, FourierPolynomialIterMut};
+
+/// Fourier-domain GLWE ciphertext.
+///
+/// ## Layout
+///
+/// ```text
+/// |--a1--| ... |--ak--|--b--|
+/// ```
+///
+/// Each component is a Fourier polynomial of length `fourier_length`.
+/// Total data length: `(k + 1) * fourier_length`.
+#[derive(Clone)]
+pub struct FourierGlwe<S>(pub S)
+where
+    S: RawData<Elem = Complex64>;
+
+impl_fourier_iters!(FourierGlwe);
+impl_fourier_core!(FourierGlwe);
+impl_fourier_iter_sub!(
+    FourierGlwe,
+    FourierPolynomialIter,
+    FourierPolynomialIterMut,
+    fourier_poly
+);
+
+// ---------------------------------------------------------------------------
+// GLWE-specific methods
+// ---------------------------------------------------------------------------
+
+impl<S> FourierGlwe<S>
+where
+    S: RawData<Elem = Complex64> + primus_data::Data,
+{
+    /// Returns the `a` components and `b` component as immutable slices.
+    ///
+    /// `mid = k * fourier_length` splits the mask from the body.
+    /// `mid` must be `<= self.0.len()`.
+    #[inline]
+    pub fn a_b_slices(&self, mid: usize) -> (&[Complex64], &[Complex64]) {
+        self.0.split_at(mid)
+    }
+}
+
+impl<S> FourierGlwe<S>
+where
+    S: RawData<Elem = Complex64> + primus_data::DataMut,
+{
+    /// Returns the `a` components and `b` component as mutable slices.
+    #[inline]
+    pub fn a_b_mut_slices(&mut self, mid: usize) -> (&mut [Complex64], &mut [Complex64]) {
+        self.0.split_at_mut(mid)
+    }
+}

--- a/crates/primus_lattice/src/glwe/mod.rs
+++ b/crates/primus_lattice/src/glwe/mod.rs
@@ -5,6 +5,7 @@ mod ntt;
 
 mod crt;
 mod dcrt;
+/// Fourier-domain GLWE ciphertexts.
 pub mod fourier;
 
 pub use big_uint::{BigUintGlwe, BigUintGlweIter, BigUintGlweIterMut};

--- a/crates/primus_lattice/src/glwe/mod.rs
+++ b/crates/primus_lattice/src/glwe/mod.rs
@@ -1,0 +1,15 @@
+mod big_uint;
+
+mod coeff;
+mod ntt;
+
+mod crt;
+mod dcrt;
+
+pub use big_uint::{BigUintGlwe, BigUintGlweIter, BigUintGlweIterMut};
+
+pub use coeff::{Glwe, GlweIter, GlweIterMut};
+pub use ntt::{NttGlwe, NttGlweIter, NttGlweIterMut};
+
+pub use crt::{CrtGlwe, CrtGlweIter, CrtGlweIterMut};
+pub use dcrt::{DcrtGlwe, DcrtGlweIter, DcrtGlweIterMut};

--- a/crates/primus_lattice/src/glwe/mod.rs
+++ b/crates/primus_lattice/src/glwe/mod.rs
@@ -5,6 +5,7 @@ mod ntt;
 
 mod crt;
 mod dcrt;
+pub mod fourier;
 
 pub use big_uint::{BigUintGlwe, BigUintGlweIter, BigUintGlweIterMut};
 
@@ -13,3 +14,4 @@ pub use ntt::{NttGlwe, NttGlweIter, NttGlweIterMut};
 
 pub use crt::{CrtGlwe, CrtGlweIter, CrtGlweIterMut};
 pub use dcrt::{DcrtGlwe, DcrtGlweIter, DcrtGlweIterMut};
+pub use fourier::{FourierGlwe, FourierGlweIter, FourierGlweIterMut, FourierGlweOwned};

--- a/crates/primus_lattice/src/glwe/ntt.rs
+++ b/crates/primus_lattice/src/glwe/ntt.rs
@@ -1,0 +1,89 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial, NttPolynomialIter, NttPolynomialIterMut};
+use primus_reduce::FieldContext;
+
+use super::Glwe;
+
+/// A cryptographic structure for Module(General) Learning with Errors (MLWE, GLWE).
+///
+/// ## Structure of the `data`
+///
+/// |--a1--|....|--ak--|--b--|
+///
+/// where `a1`...`ak` and `b` are [`NttPolynomial`] with same poly length, `k` is the dimension.
+#[derive(Clone)]
+pub struct NttGlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttGlwe<S>);
+impl_bytes_conversion!(NttGlwe<S>);
+impl_zero!(NttGlwe<S>);
+impl_iters!(NttGlwe);
+impl_iter_sub_structure!(NttGlwe<S>, NttPolynomial, ntt_poly);
+impl_basic_operation_single_modulus!(NttGlwe<S>);
+impl_intt!(NttGlwe<S>, Glwe);
+
+impl<S, T> NttGlwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Performs a modular multiplication on the `self` [`NttGlwe<S>`] with another `ntt_poly` [`NttPolynomial<A>`].
+    #[inline]
+    pub fn mul_ntt_polynomial_assign<M, A>(&mut self, ntt_poly: &NttPolynomial<A>, modulus: M)
+    where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        let poly_len = ntt_poly.poly_length();
+
+        self.iter_ntt_poly_mut(poly_len).for_each(|mut poly| {
+            poly.mul_assign(ntt_poly, modulus);
+        });
+    }
+}
+
+impl<S, T> NttGlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Extracts slice of `a` and `b` of this [`NttGlwe<S>`].
+    #[inline]
+    pub fn a_b_slices(&self, mid: usize) -> (&[T], &[T]) {
+        self.0.split_at(mid)
+    }
+
+    /// Extracts `a` and `b` of this [`NttGlwe<S>`].
+    #[inline]
+    pub fn a_b(&self, mid: usize) -> (NttPolynomialIter<'_, T>, NttPolynomial<&[T]>) {
+        let (a, b) = self.0.split_at(mid);
+        (NttPolynomialIter::new(a, b.len()), NttPolynomial(b))
+    }
+
+    /// Performs a modular multiplication on the `self` [`NttGlwe<S>`] with another `ntt_poly` [`NttPolynomial`],
+    /// stores the result into `result`.
+    #[inline]
+    pub fn mul_ntt_polynomial_to<M, A, B>(
+        &self,
+        ntt_poly: &NttPolynomial<A>,
+        result: &mut NttGlwe<B>,
+        modulus: M,
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_length = ntt_poly.poly_length();
+
+        self.iter_ntt_poly(poly_length)
+            .zip(result.iter_ntt_poly_mut(poly_length))
+            .for_each(|(x, mut y)| {
+                x.mul_to(ntt_poly, &mut y, modulus);
+            });
+    }
+}

--- a/crates/primus_lattice/src/lib.rs
+++ b/crates/primus_lattice/src/lib.rs
@@ -1,21 +1,27 @@
+#![deny(missing_docs)]
+
 //! Defines some lattice cryptographic structure.
 
 #[macro_use]
 mod macros;
 
+/// Context types and scratch buffers.
 pub mod context;
-
-pub mod lwe;
-
-pub mod glwe;
-pub mod rlwe;
-
-pub mod glev;
-pub mod rlev;
-
+/// GGSW matrix ciphertexts.
 pub mod ggsw;
-pub mod rgsw;
-
+/// GLev gadget-decomposed ciphertexts.
+pub mod glev;
+/// Module-LWE (GLWE) ciphertexts: [`coeff`](glwe), [`ntt`](crate::glwe::NttGlwe), [`fourier`](glwe::fourier).
+pub mod glwe;
+/// Standard LWE ciphertexts.
+pub mod lwe;
+/// NTRU ciphertexts.
 pub mod ntru;
-
+/// RGSW matrix ciphertexts (ring variant).
+pub mod rgsw;
+/// RLev gadget-decomposed ciphertexts (ring variant).
+pub mod rlev;
+/// Ring-LWE (RLWE) ciphertexts.
+pub mod rlwe;
+/// TFHE semantic aliases and Fourier-domain operations.
 pub mod tfhe;

--- a/crates/primus_lattice/src/lib.rs
+++ b/crates/primus_lattice/src/lib.rs
@@ -1,0 +1,19 @@
+//! Defines some lattice cryptographic structure.
+
+#[macro_use]
+mod macros;
+
+pub mod context;
+
+pub mod lwe;
+
+pub mod glwe;
+pub mod rlwe;
+
+pub mod glev;
+pub mod rlev;
+
+pub mod ggsw;
+pub mod rgsw;
+
+pub mod ntru;

--- a/crates/primus_lattice/src/lib.rs
+++ b/crates/primus_lattice/src/lib.rs
@@ -17,3 +17,5 @@ pub mod ggsw;
 pub mod rgsw;
 
 pub mod ntru;
+
+pub mod tfhe;

--- a/crates/primus_lattice/src/lwe/mod.rs
+++ b/crates/primus_lattice/src/lwe/mod.rs
@@ -1,0 +1,5 @@
+mod multiple_message;
+mod single_message;
+
+pub use multiple_message::MultiMsgLwe;
+pub use single_message::Lwe;

--- a/crates/primus_lattice/src/lwe/multiple_message.rs
+++ b/crates/primus_lattice/src/lwe/multiple_message.rs
@@ -1,0 +1,298 @@
+use std::mem::MaybeUninit;
+
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::{FheUint, Size};
+use primus_reduce::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::Lwe;
+
+/// Represents a cryptographic structure based on the Learning with Errors (LWE) problem.
+///
+/// This structure encrypts several messages like a rlwe but truncated `b`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiMsgLwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl<S, T> MultiMsgLwe<S>
+where
+    S: RawData<Elem = T> + DataOwned,
+    T: FheUint,
+{
+    /// Creates a new [`MultiMsgLwe<S, T>`] from bytes `data`.
+    #[inline]
+    pub fn from_bytes(data: &[u8]) -> Self {
+        let converted_data: &[T] = bytemuck::cast_slice(data);
+
+        Self(S::from_slice(converted_data))
+    }
+
+    /// Creates a new [`MultiMsgLwe<S, T>`].
+    #[inline]
+    pub fn new(data: S) -> Self {
+        Self(data)
+    }
+
+    /// Generates a [`MultiMsgLwe<S, T>`] with all values are `0`.
+    #[inline]
+    pub fn zero(dimension: usize, msg_count: usize) -> Self {
+        Self(S::from_vec(vec![T::ZERO; dimension + msg_count]))
+    }
+}
+
+impl<S, T> MultiMsgLwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Creates a new [`MultiMsgLwe<S, T>`] from bytes `data`.
+    #[inline]
+    pub fn read_bytes(&mut self, data: &[u8]) {
+        let converted_data: &[T] = bytemuck::cast_slice(data);
+
+        self.0.copy_from_slice(converted_data);
+    }
+
+    /// Returns mutable references to `a` and `b` of this [`MultiMsgLwe<S, T>`].
+    #[inline]
+    pub fn a_b_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+        self.0.split_at_mut(mid)
+    }
+
+    /// Sets all values to `0`.
+    #[inline]
+    pub fn set_zero(&mut self) {
+        self.0.fill(T::ZERO);
+    }
+
+    /// Perform component-wise modular addition of two [`MultiMsgLwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is not a reference.
+    /// If your `self` is a reference, you can use function `add_component_wise_ref`.
+    #[inline]
+    pub fn add_component_wise<M, A>(mut self, rhs: &MultiMsgLwe<A>, modulus: M) -> Self
+    where
+        M: Copy + ReduceAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        self.add_component_wise_assign(rhs, modulus);
+        self
+    }
+
+    /// Performs an in-place component-wise modular addition
+    /// on the `self` [`MultiMsgLwe<S, T>`] with another `rhs` [`MultiMsgLwe<S, T>`].
+    #[inline]
+    pub fn add_component_wise_assign<M, A>(&mut self, rhs: &MultiMsgLwe<A>, modulus: M)
+    where
+        M: Copy + ReduceAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        modulus.reduce_add_slice_assign(self.0.as_mut_slice(), rhs.0.as_slice());
+    }
+
+    /// Perform component-wise modular subtraction of two [`MultiMsgLwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is not a reference.
+    /// If your `self` is a reference, you can use function `sub_component_wise_ref`.
+    #[inline]
+    pub fn sub_component_wise<M, A>(mut self, rhs: &MultiMsgLwe<A>, modulus: M) -> Self
+    where
+        M: Copy + ReduceSubSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        self.sub_component_wise_assign(rhs, modulus);
+        self
+    }
+
+    /// Performs an in-place component-wise modular subtraction
+    /// on the `self` [`MultiMsgLwe<S, T>`] with another `rhs` [`MultiMsgLwe<S, T>`].
+    #[inline]
+    pub fn sub_component_wise_assign<M, A>(&mut self, rhs: &MultiMsgLwe<A>, modulus: M)
+    where
+        M: Copy + ReduceSubSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        modulus.reduce_sub_slice_assign(self.0.as_mut_slice(), rhs.0.as_slice());
+    }
+
+    /// Performs an in-place modular scalar multiplication
+    /// on the `self` [`MultiMsgLwe<S, T>`] with scalar `T`.
+    #[inline]
+    pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
+    where
+        M: Copy + ReduceMulSlice<T>,
+    {
+        modulus.reduce_mul_scalar_slice_assign(self.0.as_mut_slice(), scalar);
+    }
+
+    /// Performs an in-place modular scalar multiplication
+    /// on the `rhs` [`MultiMsgLwe<S, T>`] with `scalar` `T`,
+    /// then add to `self`.
+    #[inline]
+    pub fn add_mul_scalar_assign<M, A>(&mut self, rhs: &MultiMsgLwe<A>, scalar: T, modulus: M)
+    where
+        M: Copy + ReduceMulAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        modulus.reduce_add_mul_scalar_slice_assign(self.0.as_mut_slice(), rhs.0.as_slice(), scalar);
+    }
+}
+
+impl<S, T> MultiMsgLwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Converts [`MultiMsgLwe<S, T>`] into bytes.
+    #[inline]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let data: &[u8] = bytemuck::cast_slice(self.0.as_slice());
+
+        data.to_vec()
+    }
+
+    /// Converts [`MultiMsgLwe<S, T>`] into bytes, stored in `data`.
+    #[inline]
+    pub fn write_bytes(&self, data: &mut [u8]) {
+        let src: &[u8] = bytemuck::cast_slice(self.0.as_slice());
+
+        assert_eq!(data.len(), src.len());
+
+        data.copy_from_slice(src);
+    }
+
+    /// Returns references to `a` and `b` of this [`MultiMsgLwe<S, T>`].
+    #[inline]
+    pub fn a_b(&self, mid: usize) -> (&[T], &[T]) {
+        self.0.split_at(mid)
+    }
+
+    /// Perform component-wise modular addition of two [`MultiMsgLwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is a reference.
+    /// If your `self` is not a reference, you can use function `add_component_wise`.
+    #[inline]
+    pub fn add_component_wise_ref<M, A, B>(
+        &self,
+        rhs: &MultiMsgLwe<A>,
+        modulus: M,
+    ) -> MultiMsgLwe<B>
+    where
+        M: Copy + ReduceAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataOwned,
+    {
+        let len = self.0.len();
+
+        debug_assert_eq!(self.0.len(), rhs.0.len());
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(len);
+        unsafe {
+            data.set_len(len);
+        }
+
+        modulus.reduce_add_slice_to(self.0.as_slice(), rhs.0.as_slice(), unsafe {
+            data.as_mut_slice().assume_init_mut()
+        });
+
+        let data = unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) };
+
+        MultiMsgLwe::new(B::from_vec(data))
+    }
+
+    /// Perform component-wise modular subtraction of two [`MultiMsgLwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is a reference.
+    /// If your `self` is not a reference, you can use function `sub_component_wise`.
+    #[inline]
+    pub fn sub_component_wise_ref<M, A, B>(
+        &self,
+        rhs: &MultiMsgLwe<A>,
+        modulus: M,
+    ) -> MultiMsgLwe<B>
+    where
+        M: Copy + ReduceSubSlice<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataOwned,
+    {
+        let len = self.0.len();
+
+        debug_assert_eq!(self.0.len(), rhs.0.len());
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(len);
+        unsafe {
+            data.set_len(len);
+        }
+
+        modulus.reduce_sub_slice_to(self.0.as_slice(), rhs.0.as_slice(), unsafe {
+            data.as_mut_slice().assume_init_mut()
+        });
+
+        let data = unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) };
+
+        MultiMsgLwe::new(B::from_vec(data))
+    }
+}
+
+impl<T: FheUint> MultiMsgLwe<Vec<T>> {
+    /// Sample extract [`Lwe<Vec<T>>`].
+    #[inline]
+    pub fn extract_rlwe_mode<M>(&self, dimension: usize, index: usize, modulus: M) -> Lwe<Vec<T>>
+    where
+        M: Copy + ReduceNegSlice<T>,
+    {
+        let mut data = self.0[..dimension + 1].to_vec();
+        if index == 0 {
+            Lwe::new(data)
+        } else {
+            data[..dimension].rotate_right(index);
+            modulus.reduce_neg_slice_assign(&mut data[..index]);
+            data[dimension] = self.0[dimension + index];
+            Lwe::new(data)
+        }
+    }
+
+    /// Sample extract all [`Lwe<T>`].
+    #[inline]
+    pub fn extract_all<M>(&self, msg_count: usize, modulus: M) -> Vec<Lwe<Vec<T>>>
+    where
+        M: Copy + ReduceNegAssign<T>,
+    {
+        let dimension = self.0.len() - msg_count;
+        let mut result = Vec::with_capacity(msg_count);
+
+        let mut data = self.0[..dimension].to_vec();
+        self.0[dimension + 1..].iter().for_each(|&b| {
+            let lwe = Lwe::new(data.clone());
+            result.push(lwe);
+
+            data[..dimension].rotate_right(1);
+            modulus.reduce_neg_assign(&mut data[0]);
+            data[dimension] = b;
+        });
+        result.push(Lwe::new(data));
+
+        result
+    }
+}
+
+impl<S, T> Size for MultiMsgLwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    #[inline]
+    fn byte_count(&self) -> usize {
+        self.0.len() * T::BYTES
+    }
+}

--- a/crates/primus_lattice/src/lwe/single_message.rs
+++ b/crates/primus_lattice/src/lwe/single_message.rs
@@ -173,6 +173,7 @@ where
         *self.0.as_slice().last().unwrap()
     }
 
+    /// Returns a reference to `a` and the value of `b` of this LWE sample.
     pub fn a_b(&self) -> (&[T], T) {
         let (b, a) = self.0.as_slice().split_last().unwrap();
         (a, *b)

--- a/crates/primus_lattice/src/lwe/single_message.rs
+++ b/crates/primus_lattice/src/lwe/single_message.rs
@@ -1,0 +1,379 @@
+use std::mem::MaybeUninit;
+
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_distr::DiscreteGaussian;
+use primus_integer::{FheUint, Size};
+use primus_reduce::{Modulus, prelude::*};
+use rand::distr::{Distribution, Uniform};
+use serde::{Deserialize, Serialize};
+
+/// Represents a cryptographic structure based on the Learning with Errors (LWE) problem.
+/// The LWE problem is a fundamental component in modern cryptography, often used to build
+/// secure cryptographic systems that are considered hard to crack by quantum computers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + DataOwned,
+    T: FheUint,
+{
+    /// Creates a new [`Lwe<S, T>`] from bytes `data`.
+    #[inline]
+    pub fn from_bytes(data: &[u8]) -> Self {
+        let converted_data: &[T] = bytemuck::cast_slice(data);
+
+        Self(DataOwned::from_slice(converted_data))
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Creates a new [`Lwe<S, T>`] from bytes `data`.
+    #[inline]
+    pub fn read_bytes(&mut self, data: &[u8]) {
+        let converted_data: &[T] = bytemuck::cast_slice(data);
+
+        self.0.copy_from_slice(converted_data);
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Converts [`Lwe<S, T>`] into bytes.
+    #[inline]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let data: &[u8] = bytemuck::cast_slice(self.0.as_slice());
+        data.to_vec()
+    }
+
+    /// Converts [`Lwe<S, T>`] into bytes, stored in `data`.
+    #[inline]
+    pub fn write_bytes(&self, data: &mut [u8]) {
+        let src: &[u8] = bytemuck::cast_slice(self.0.as_slice());
+
+        assert_eq!(data.len(), src.len());
+
+        data.copy_from_slice(src);
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + DataOwned,
+    T: FheUint,
+{
+    /// Creates a new [`Lwe<S, T>`].
+    #[inline]
+    pub fn new(data: S) -> Self {
+        Self(data)
+    }
+
+    /// Generates a [`Lwe<S, T>`] with all values are `0`.
+    #[inline]
+    pub fn zero(dimension: usize) -> Self {
+        Self(S::from_vec(vec![T::ZERO; dimension + 1]))
+    }
+}
+
+impl<T> Lwe<Vec<T>>
+where
+    T: FheUint,
+{
+    /// Generate a [`Lwe<S, T>`] sample which encrypts `0`.
+    #[inline]
+    pub fn generate_random_zero_sample<M, R>(
+        secret_key: &[T],
+        modulus: M,
+        uniform: Uniform<T>,
+        gaussian: &DiscreteGaussian<T>,
+        rng: &mut R,
+    ) -> Self
+    where
+        M: Copy + Modulus<ValueT = T> + ReduceDotProduct<T, Output = T> + ReduceAdd<T, Output = T>,
+        R: rand::Rng + rand::CryptoRng,
+    {
+        let len = secret_key.len();
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(len + 1);
+        unsafe {
+            data.set_len(len + 1);
+        }
+        data[0..len]
+            .iter_mut()
+            .zip(uniform.sample_iter(&mut *rng))
+            .for_each(|(x, y)| {
+                x.write(y);
+            });
+        data[len].write(gaussian.sample(rng));
+
+        let mut data = unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) };
+
+        let b = modulus.reduce_dot_product(&data[0..len], secret_key);
+        data[len] = modulus.reduce_add(b, data[len]);
+
+        Lwe(data)
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Returns a mutable reference to the `a` of this [`Lwe<S, T>`].
+    #[inline]
+    pub fn a_mut(&mut self) -> &mut [T] {
+        self.0.as_mut_slice().split_last_mut().unwrap().1
+    }
+
+    /// Returns a mutable reference to the `b` of this [`Lwe<S, T>`].
+    #[inline]
+    pub fn b_mut(&mut self) -> &mut T {
+        self.0.as_mut_slice().last_mut().unwrap()
+    }
+
+    /// Returns mutable references to `a` and `b` of this [`Lwe<S, T>`].
+    #[inline]
+    pub fn a_b_mut(&mut self) -> (&mut [T], &mut T) {
+        let (b, a) = self.0.as_mut_slice().split_last_mut().unwrap();
+        (a, b)
+    }
+
+    /// Sets all values to `0`.
+    #[inline]
+    pub fn set_zero(&mut self) {
+        self.0.fill(T::ZERO);
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Returns a reference to the `a` of this [`Lwe<S, T>`].
+    #[inline]
+    pub fn a(&self) -> &[T] {
+        self.0.as_slice().split_last().unwrap().1
+    }
+
+    /// Returns the `b` of this [`Lwe<S, T>`].
+    #[inline]
+    pub fn b(&self) -> T {
+        *self.0.as_slice().last().unwrap()
+    }
+
+    pub fn a_b(&self) -> (&[T], T) {
+        let (b, a) = self.0.as_slice().split_last().unwrap();
+        (a, *b)
+    }
+
+    /// Returns the dimension of this [`Lwe<S, T>`].
+    #[inline]
+    pub fn dimension(&self) -> usize {
+        self.0.len() - 1
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Performs component-wise modular addition of two [`Lwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is not a reference.
+    /// If your `self` is a reference, you can use function `add_component_wise_ref`.
+    #[inline]
+    pub fn add_component_wise<M, A>(mut self, rhs: &Lwe<A>, modulus: M) -> Self
+    where
+        M: Copy + ReduceAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        self.add_component_wise_assign(rhs, modulus);
+        self
+    }
+
+    /// Performs an in-place component-wise modular addition
+    /// on the `self` [`Lwe<S, T>`] with another `rhs` [`Lwe<S, T>`].
+    #[inline]
+    pub fn add_component_wise_assign<M, A>(&mut self, rhs: &Lwe<A>, modulus: M)
+    where
+        M: Copy + ReduceAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        modulus.reduce_add_slice_assign(self.0.as_mut_slice(), rhs.0.as_slice());
+    }
+
+    /// Performs component-wise modular subtraction of two [`Lwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is not a reference.
+    /// If your `self` is a reference, you can use function `sub_component_wise_ref`.
+    #[inline]
+    pub fn sub_component_wise<M, A>(mut self, rhs: &Lwe<A>, modulus: M) -> Self
+    where
+        M: Copy + ReduceSubSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        self.sub_component_wise_assign(rhs, modulus);
+        self
+    }
+
+    /// Performs an in-place component-wise modular subtraction
+    /// on the `self` [`Lwe<S, T>`] with another `rhs` [`Lwe<S, T>`].
+    #[inline]
+    pub fn sub_component_wise_assign<M, A>(&mut self, rhs: &Lwe<A>, modulus: M)
+    where
+        M: Copy + ReduceSubSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        modulus.reduce_sub_slice_assign(self.0.as_mut_slice(), rhs.0.as_slice());
+    }
+
+    /// Performs an in-place modular scalar multiplication
+    /// on the `self` [`Lwe<S, T>`] with scalar `T`.
+    #[inline]
+    pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
+    where
+        M: Copy + ReduceMulSlice<T>,
+    {
+        modulus.reduce_mul_scalar_slice_assign(self.0.as_mut_slice(), scalar);
+    }
+
+    /// Performs an in-place modular scalar multiplication
+    /// on the `rhs` [`Lwe<S, T>`] with `scalar` `T`,
+    /// then add to `self`.
+    #[inline]
+    pub fn add_mul_scalar_assign<M, A>(&mut self, rhs: &Lwe<A>, scalar: T, modulus: M)
+    where
+        M: Copy + ReduceMulAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        modulus.reduce_add_mul_scalar_slice_assign(self.0.as_mut_slice(), rhs.0.as_slice(), scalar);
+    }
+
+    /// Performs an negation on the `self` [`Lwe<S, T>`].
+    #[inline]
+    pub fn neg_assign<M>(&mut self, modulus: M)
+    where
+        M: Copy + ReduceNegSlice<T>,
+    {
+        modulus.reduce_neg_slice_assign(self.0.as_mut_slice());
+    }
+}
+
+impl<S, T> Lwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Performs component-wise modular addition of two [`Lwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is a reference.
+    /// If your `self` is not a reference, you can use function `add_component_wise`.
+    #[inline]
+    pub fn add_component_wise_ref<M, A, B>(&self, rhs: &Lwe<A>, modulus: M) -> Lwe<B>
+    where
+        M: Copy + ReduceAddSlice<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataOwned,
+    {
+        let len = self.0.len();
+
+        debug_assert_eq!(self.0.len(), rhs.0.len());
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(len);
+        unsafe {
+            data.set_len(len);
+        }
+
+        modulus.reduce_add_slice_to(self.0.as_slice(), rhs.0.as_slice(), unsafe {
+            data.as_mut_slice().assume_init_mut()
+        });
+
+        let data = unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) };
+
+        Lwe::new(B::from_vec(data))
+    }
+
+    /// Performs component-wise modular subtraction of two [`Lwe<S, T>`].
+    ///
+    /// # Attention
+    ///
+    /// In this function, `self` is a reference.
+    /// If your `self` is not a reference, you can use function `sub_component_wise`.
+    #[inline]
+    pub fn sub_component_wise_ref<M, A, B>(&self, rhs: &Lwe<A>, modulus: M) -> Lwe<B>
+    where
+        M: Copy + ReduceSubSlice<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataOwned,
+    {
+        let len = self.0.len();
+
+        debug_assert_eq!(self.0.len(), rhs.0.len());
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(len);
+        unsafe {
+            data.set_len(len);
+        }
+
+        modulus.reduce_sub_slice_to(self.0.as_slice(), rhs.0.as_slice(), unsafe {
+            data.as_mut_slice().assume_init_mut()
+        });
+
+        let data = unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) };
+
+        Lwe::new(B::from_vec(data))
+    }
+
+    /// Performs a modular negation on the `self` [`Lwe<S, T>`].
+    #[inline]
+    pub fn neg<M, A>(&self, modulus: M) -> Lwe<A>
+    where
+        M: Copy + ReduceNegSlice<T>,
+        A: RawData<Elem = T> + DataOwned,
+    {
+        let len = self.0.len();
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(len);
+        unsafe {
+            data.set_len(len);
+        }
+
+        modulus.reduce_neg_slice_to(self.0.as_slice(), unsafe {
+            data.as_mut_slice().assume_init_mut()
+        });
+
+        let data = unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) };
+
+        Lwe::new(A::from_vec(data))
+    }
+}
+
+impl<S, T> Size for Lwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    #[inline]
+    fn byte_count(&self) -> usize {
+        self.0.len() * T::BYTES
+    }
+}

--- a/crates/primus_lattice/src/macros/mod.rs
+++ b/crates/primus_lattice/src/macros/mod.rs
@@ -128,6 +128,7 @@ macro_rules! impl_zero {
 macro_rules! impl_iters {
     ($cipher:ident) => {
         paste::paste! {
+            #[doc = concat!("Immutable chunked iterator over [`", stringify!($cipher), "`] ciphertexts.")]
             pub struct [<$cipher Iter>]<'a, T>
             where
                 T: FheUint,
@@ -136,6 +137,7 @@ macro_rules! impl_iters {
             }
 
             impl<'a, T: FheUint> [<$cipher Iter>]<'a, T> {
+                #[doc = concat!("Creates an iterator yielding `", stringify!($cipher), "` chunks of `", stringify!([<$cipher:snake _len>]), "` elements each.")]
                 #[inline]
                 pub fn new(data:&'a [T], [<$cipher:snake _len>]:usize) -> Self{
                     Self {
@@ -157,6 +159,7 @@ macro_rules! impl_iters {
         }
 
         paste::paste! {
+            #[doc = concat!("Mutable chunked iterator over [`", stringify!($cipher), "`] ciphertexts.")]
             pub struct [<$cipher IterMut>]<'a, T>
             where
                 T: FheUint,
@@ -165,6 +168,7 @@ macro_rules! impl_iters {
             }
 
             impl<'a, T: FheUint> [<$cipher IterMut>]<'a, T> {
+                #[doc = concat!("Creates a mutable iterator yielding `", stringify!($cipher), "` chunks of `", stringify!([<$cipher:snake _len>]), "` elements each.")]
                 #[inline]
                 pub fn new(data:&'a mut [T], [<$cipher:snake _len>]:usize) -> Self{
                     Self {
@@ -195,6 +199,7 @@ macro_rules! impl_iter_sub_structure {
             T: FheUint,
         {
             paste::paste! {
+                #[doc = concat!("Returns an iterator over the `", stringify!($sub), "` sub-components of this `", stringify!($cipher), "`.")]
                 #[inline]
                 pub fn [<iter_ $sub:snake>]<'a>(&'a self, [<$sub:snake _len>]: usize) -> [<$sub Iter>]<'a, T> {
                     [<$sub Iter>] {
@@ -211,6 +216,7 @@ macro_rules! impl_iter_sub_structure {
             T: FheUint,
         {
             paste::paste! {
+                #[doc = concat!("Returns a mutable iterator over the `", stringify!($sub), "` sub-components of this `", stringify!($cipher), "`.")]
                 #[inline]
                 pub fn [<iter_ $sub:snake _mut>]<'a>(
                     &'a mut self,
@@ -230,6 +236,7 @@ macro_rules! impl_iter_sub_structure {
             T: FheUint,
         {
             paste::paste! {
+                #[doc = concat!("Returns an iterator over the `", stringify!($sub), "` sub-components of this `", stringify!($cipher), "`.")]
                 #[inline]
                 pub fn [<iter_ $sub_short>]<'a>(&'a self, [<$sub_short _len>]: usize) -> [<$sub Iter>]<'a, T> {
                     [<$sub Iter>] {
@@ -246,6 +253,7 @@ macro_rules! impl_iter_sub_structure {
             T: FheUint,
         {
             paste::paste! {
+                #[doc = concat!("Returns a mutable iterator over the `", stringify!($sub), "` sub-components of this `", stringify!($cipher), "`.")]
                 #[inline]
                 pub fn [<iter_ $sub_short _mut>]<'a>(
                     &'a mut self,
@@ -668,12 +676,22 @@ macro_rules! impl_crt_ntt {
 macro_rules! impl_fourier_iters {
     ($cipher:ident) => {
         paste::paste! {
+            #[doc = concat!(
+                "Immutable chunked iterator over [`",
+                stringify!($cipher),
+                "`] ciphertexts."
+            )]
             #[derive(Debug, Clone)]
             pub struct [<$cipher Iter>]<'a> {
                 iter: core::slice::ChunksExact<'a, num_complex::Complex64>,
             }
 
             impl<'a> [<$cipher Iter>]<'a> {
+                #[doc = concat!(
+                    "Creates an iterator yielding `",
+                    stringify!($cipher),
+                    "` chunks of `chunk_len` elements each."
+                )]
                 #[inline]
                 pub fn new(data: &'a [num_complex::Complex64], chunk_len: usize) -> Self {
                     Self {
@@ -701,12 +719,22 @@ macro_rules! impl_fourier_iters {
         }
 
         paste::paste! {
+            #[doc = concat!(
+                "Mutable chunked iterator over [`",
+                stringify!($cipher),
+                "`] ciphertexts."
+            )]
             #[derive(Debug)]
             pub struct [<$cipher IterMut>]<'a> {
                 iter: core::slice::ChunksExactMut<'a, num_complex::Complex64>,
             }
 
             impl<'a> [<$cipher IterMut>]<'a> {
+                #[doc = concat!(
+                    "Creates a mutable iterator yielding `",
+                    stringify!($cipher),
+                    "` chunks of `chunk_len` elements each."
+                )]
                 #[inline]
                 pub fn new(data: &'a mut [num_complex::Complex64], chunk_len: usize) -> Self {
                     Self {
@@ -740,7 +768,7 @@ macro_rules! impl_fourier_iters {
 macro_rules! impl_fourier_core {
     ($cipher:ident) => {
         paste::paste! {
-            /// Owned [`$cipher`] backed by a [`Vec`].
+            #[doc = concat!("Owned [`", stringify!($cipher), "`] backed by a [`Vec`].")]
             pub type [<$cipher Owned>] = $cipher<Vec<num_complex::Complex64>>;
         }
 

--- a/crates/primus_lattice/src/macros/mod.rs
+++ b/crates/primus_lattice/src/macros/mod.rs
@@ -659,6 +659,200 @@ macro_rules! impl_crt_ntt {
     };
 }
 
+// --------------------------------------------------------------------------
+// Fourier-domain macros (Complex64 element, no FheUint requirement)
+// --------------------------------------------------------------------------
+
+/// Generates `{Cipher}Iter<'a>` and `{Cipher}IterMut<'a>` chunked iterator
+/// types for a Fourier ciphertext over `Complex64` elements.
+macro_rules! impl_fourier_iters {
+    ($cipher:ident) => {
+        paste::paste! {
+            #[derive(Debug, Clone)]
+            pub struct [<$cipher Iter>]<'a> {
+                iter: core::slice::ChunksExact<'a, num_complex::Complex64>,
+            }
+
+            impl<'a> [<$cipher Iter>]<'a> {
+                #[inline]
+                pub fn new(data: &'a [num_complex::Complex64], chunk_len: usize) -> Self {
+                    Self {
+                        iter: data.chunks_exact(chunk_len),
+                    }
+                }
+            }
+
+            impl<'a> Iterator for [<$cipher Iter>]<'a> {
+                type Item = $cipher<&'a [num_complex::Complex64]>;
+
+                #[inline]
+                fn next(&mut self) -> Option<Self::Item> {
+                    self.iter.next().map($cipher)
+                }
+
+                #[inline]
+                fn size_hint(&self) -> (usize, Option<usize>) {
+                    self.iter.size_hint()
+                }
+            }
+
+            impl<'a> core::iter::FusedIterator for [<$cipher Iter>]<'a> {}
+            impl<'a> core::iter::ExactSizeIterator for [<$cipher Iter>]<'a> {}
+        }
+
+        paste::paste! {
+            #[derive(Debug)]
+            pub struct [<$cipher IterMut>]<'a> {
+                iter: core::slice::ChunksExactMut<'a, num_complex::Complex64>,
+            }
+
+            impl<'a> [<$cipher IterMut>]<'a> {
+                #[inline]
+                pub fn new(data: &'a mut [num_complex::Complex64], chunk_len: usize) -> Self {
+                    Self {
+                        iter: data.chunks_exact_mut(chunk_len),
+                    }
+                }
+            }
+
+            impl<'a> Iterator for [<$cipher IterMut>]<'a> {
+                type Item = $cipher<&'a mut [num_complex::Complex64]>;
+
+                #[inline]
+                fn next(&mut self) -> Option<Self::Item> {
+                    self.iter.next().map($cipher)
+                }
+
+                #[inline]
+                fn size_hint(&self) -> (usize, Option<usize>) {
+                    self.iter.size_hint()
+                }
+            }
+
+            impl<'a> core::iter::FusedIterator for [<$cipher IterMut>]<'a> {}
+            impl<'a> core::iter::ExactSizeIterator for [<$cipher IterMut>]<'a> {}
+        }
+    };
+}
+
+/// Generates `{Cipher}Owned` type alias and core methods (`new`, `zero`,
+/// `set_zero`, `as_ref`, `as_mut`, `byte_count`) for a Fourier ciphertext.
+macro_rules! impl_fourier_core {
+    ($cipher:ident) => {
+        paste::paste! {
+            /// Owned [`$cipher`] backed by a [`Vec`].
+            pub type [<$cipher Owned>] = $cipher<Vec<num_complex::Complex64>>;
+        }
+
+        impl<S> $cipher<S>
+        where
+            S: primus_data::RawData<Elem = num_complex::Complex64>,
+        {
+            #[doc = concat!("Creates a new [`", stringify!($cipher), "`].")]
+            #[inline]
+            pub fn new(data: S) -> Self {
+                Self(data)
+            }
+        }
+
+        impl<S> $cipher<S>
+        where
+            S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::DataOwned,
+        {
+            paste::paste! {
+                #[doc = concat!("Creates a zero-initialized [`", stringify!($cipher), "`].")]
+                #[inline]
+                pub fn zero([< $cipher:snake _len >]: usize) -> Self {
+                    Self(S::from_vec(vec![
+                        num_complex::Complex64::new(0.0, 0.0);
+                        [< $cipher:snake _len >]
+                    ]))
+                }
+            }
+        }
+
+        impl<S> $cipher<S>
+        where
+            S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::DataMut,
+        {
+            /// Sets all elements to zero.
+            #[inline]
+            pub fn set_zero(&mut self) {
+                self.0.fill(num_complex::Complex64::new(0.0, 0.0));
+            }
+
+            /// Returns a mutable slice of all elements.
+            #[inline]
+            pub fn as_mut(&mut self) -> &mut [num_complex::Complex64] {
+                self.0.as_mut_slice()
+            }
+        }
+
+        impl<S> $cipher<S>
+        where
+            S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::Data,
+        {
+            /// Returns a read-only slice of all elements.
+            #[inline]
+            pub fn as_ref(&self) -> &[num_complex::Complex64] {
+                self.0.as_slice()
+            }
+
+            /// Returns the total byte count.
+            #[inline]
+            pub fn byte_count(&self) -> usize {
+                self.0.len() * core::mem::size_of::<num_complex::Complex64>()
+            }
+        }
+    };
+}
+
+/// Generates sub-structure iteration methods for a Fourier ciphertext.
+///
+/// - `$sub_iter` / `$sub_iter_mut`: the sub-component's iterator types
+/// - `$method`: the method name prefix (e.g., `fourier_poly` → `iter_fourier_poly`)
+macro_rules! impl_fourier_iter_sub {
+    ($cipher:ident, $sub_iter:ident, $sub_iter_mut:ident, $method:ident) => {
+        paste::paste! {
+            impl<S> $cipher<S>
+            where
+                S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::Data,
+            {
+                #[doc = concat!(
+                    "Returns an iterator over the [`",
+                    stringify!($sub_iter),
+                    "`] sub-components."
+                )]
+                #[inline]
+                pub fn [<iter_ $method>](
+                    &self,
+                    sub_len: usize,
+                ) -> $sub_iter<'_> {
+                    $sub_iter::new(self.as_ref(), sub_len)
+                }
+            }
+
+            impl<S> $cipher<S>
+            where
+                S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::DataMut,
+            {
+                #[doc = concat!(
+                    "Returns a mutable iterator over the [`",
+                    stringify!($sub_iter_mut),
+                    "`] sub-components."
+                )]
+                #[inline]
+                pub fn [<iter_ $method _mut>](
+                    &mut self,
+                    sub_len: usize,
+                ) -> $sub_iter_mut<'_> {
+                    $sub_iter_mut::new(self.0.as_mut_slice(), sub_len)
+                }
+            }
+        }
+    };
+}
+
 macro_rules! impl_crt_intt {
     ($ntt_cipher:ident < $s:ident >,$cipher:ident) => {
         impl<$s, T> $ntt_cipher<$s>

--- a/crates/primus_lattice/src/macros/mod.rs
+++ b/crates/primus_lattice/src/macros/mod.rs
@@ -780,28 +780,36 @@ macro_rules! impl_fourier_core {
             pub fn set_zero(&mut self) {
                 self.0.fill(num_complex::Complex64::new(0.0, 0.0));
             }
-
-            /// Returns a mutable slice of all elements.
-            #[inline]
-            pub fn as_mut(&mut self) -> &mut [num_complex::Complex64] {
-                self.0.as_mut_slice()
-            }
         }
 
         impl<S> $cipher<S>
         where
             S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::Data,
         {
-            /// Returns a read-only slice of all elements.
-            #[inline]
-            pub fn as_ref(&self) -> &[num_complex::Complex64] {
-                self.0.as_slice()
-            }
-
             /// Returns the total byte count.
             #[inline]
             pub fn byte_count(&self) -> usize {
                 self.0.len() * core::mem::size_of::<num_complex::Complex64>()
+            }
+        }
+
+        impl<S> core::convert::AsRef<[num_complex::Complex64]> for $cipher<S>
+        where
+            S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::Data,
+        {
+            #[inline]
+            fn as_ref(&self) -> &[num_complex::Complex64] {
+                self.0.as_slice()
+            }
+        }
+
+        impl<S> core::convert::AsMut<[num_complex::Complex64]> for $cipher<S>
+        where
+            S: primus_data::RawData<Elem = num_complex::Complex64> + primus_data::DataMut,
+        {
+            #[inline]
+            fn as_mut(&mut self) -> &mut [num_complex::Complex64] {
+                self.0.as_mut_slice()
             }
         }
     };

--- a/crates/primus_lattice/src/macros/mod.rs
+++ b/crates/primus_lattice/src/macros/mod.rs
@@ -1,0 +1,707 @@
+macro_rules! impl_common {
+    ($cipher:ident < $s:ident >) => {
+        impl<$s> $cipher<$s>
+        where
+            $s: RawData,
+            <$s as RawData>::Elem: FheUint,
+        {
+            #[doc = concat!(r" Creates a new [`",stringify!($cipher),"<",stringify!($s),">`].")]
+            #[inline(always)]
+            pub fn new(data: $s) -> Self {
+                Self(data)
+            }
+        }
+
+        impl<$s, T> AsRef<[T]> for $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            #[inline(always)]
+            fn as_ref(&self) -> &[T] {
+                self.0.as_slice()
+            }
+        }
+
+        impl<$s, T> AsMut<[T]> for $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            #[inline(always)]
+            fn as_mut(&mut self) -> &mut [T] {
+                self.0.as_mut_slice()
+            }
+        }
+    };
+}
+
+macro_rules! impl_bytes_conversion {
+    ($cipher:ident < $s:ident >) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataOwned,
+            T: FheUint,
+        {
+            #[doc = concat!(r" Creates a new [`",stringify!($cipher),"<",stringify!($s),">`] from bytes `data`.")]
+            #[inline]
+            pub fn from_bytes(data: &[u8]) -> Self {
+                let converted_data: &[T] = bytemuck::cast_slice(data);
+
+                Self(<$s>::from_slice(converted_data))
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Copy from bytes `data`.
+            #[inline]
+            pub fn read_bytes(&mut self, data: &[u8]) {
+                let converted_data: &[T] = bytemuck::cast_slice(data);
+
+                self.0.copy_from_slice(converted_data);
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Converts `self` into bytes.
+            #[inline]
+            pub fn to_bytes(&self) -> Vec<u8> {
+                let converted_data: &[u8] = bytemuck::cast_slice(self.as_ref());
+
+                converted_data.to_vec()
+            }
+
+            /// Converts `self` into bytes, stored in `data`.
+            #[inline]
+            pub fn write_bytes(&self, data: &mut [u8]) {
+                let converted_data: &[u8] = bytemuck::cast_slice(self.as_ref());
+
+                data.copy_from_slice(converted_data);
+            }
+
+            /// Returns the bytes count.
+            #[inline]
+            pub fn byte_count(&self) -> usize {
+                self.0.len() * T::BYTES
+            }
+        }
+    };
+}
+
+macro_rules! impl_zero {
+    ($cipher:ident < $s:ident >) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataOwned,
+            T: FheUint,
+        {
+            paste::paste! {
+                #[doc = concat!(r" Creates a new [`",stringify!($cipher),"<",stringify!($s),">`] with all values or coefficients equal to zero.")]
+                #[inline]
+                pub fn zero([<$cipher:snake _len>]: usize) -> Self {
+                    Self(<$s>::from_vec(vec![T::ZERO; [<$cipher:snake _len>]]))
+                }
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Set all values or coefficients equal to zero.
+            #[inline]
+            pub fn set_zero(&mut self) {
+                self.0.fill(T::ZERO);
+            }
+        }
+    };
+}
+macro_rules! impl_iters {
+    ($cipher:ident) => {
+        paste::paste! {
+            pub struct [<$cipher Iter>]<'a, T>
+            where
+                T: FheUint,
+            {
+                pub(crate) iter: core::slice::ChunksExact<'a, T>
+            }
+
+            impl<'a, T: FheUint> [<$cipher Iter>]<'a, T> {
+                #[inline]
+                pub fn new(data:&'a [T], [<$cipher:snake _len>]:usize) -> Self{
+                    Self {
+                        iter: data.chunks_exact([<$cipher:snake _len>])
+                    }
+                }
+            }
+
+            impl<'a, T: FheUint> Iterator for [<$cipher Iter>]<'a, T> {
+                type Item = $cipher<&'a [T]>;
+
+                #[inline]
+                fn next(&mut self) -> Option<Self::Item> {
+                    self.iter.next().map(|slice| $cipher(slice))
+                }
+            }
+
+            impl<'a, T: FheUint> core::iter::FusedIterator for [<$cipher Iter>]<'a, T> {}
+        }
+
+        paste::paste! {
+            pub struct [<$cipher IterMut>]<'a, T>
+            where
+                T: FheUint,
+            {
+                pub(crate) iter: core::slice::ChunksExactMut<'a, T>
+            }
+
+            impl<'a, T: FheUint> [<$cipher IterMut>]<'a, T> {
+                #[inline]
+                pub fn new(data:&'a mut [T], [<$cipher:snake _len>]:usize) -> Self{
+                    Self {
+                        iter: data.chunks_exact_mut([<$cipher:snake _len>])
+                    }
+                }
+            }
+
+            impl<'a, T: FheUint> Iterator for [<$cipher IterMut>]<'a, T> {
+                type Item = $cipher<&'a mut [T]>;
+
+                #[inline]
+                fn next(&mut self) -> Option<Self::Item> {
+                    self.iter.next().map(|slice| $cipher(slice))
+                }
+            }
+
+            impl<'a, T: FheUint> core::iter::FusedIterator for [<$cipher IterMut>]<'a, T> {}
+        }
+    };
+}
+
+macro_rules! impl_iter_sub_structure {
+    ($cipher:ident < $s:ident >, $sub:ident) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            paste::paste! {
+                #[inline]
+                pub fn [<iter_ $sub:snake>]<'a>(&'a self, [<$sub:snake _len>]: usize) -> [<$sub Iter>]<'a, T> {
+                    [<$sub Iter>] {
+                        iter: self.0.chunks_exact([<$sub:snake _len>])
+                    }
+
+                }
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            paste::paste! {
+                #[inline]
+                pub fn [<iter_ $sub:snake _mut>]<'a>(
+                    &'a mut self,
+                    [<$sub:snake _len>]: usize,
+                ) -> [<$sub IterMut>]<'a, T> {
+                    [<$sub IterMut>] {
+                        iter: self.0.chunks_exact_mut([<$sub:snake _len>])
+                    }
+                }
+            }
+        }
+    };
+    ($cipher:ident < $s:ident >, $sub:ident, $sub_short:ident) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            paste::paste! {
+                #[inline]
+                pub fn [<iter_ $sub_short>]<'a>(&'a self, [<$sub_short _len>]: usize) -> [<$sub Iter>]<'a, T> {
+                    [<$sub Iter>] {
+                        iter: self.0.chunks_exact([<$sub_short _len>])
+                    }
+
+                }
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            paste::paste! {
+                #[inline]
+                pub fn [<iter_ $sub_short _mut>]<'a>(
+                    &'a mut self,
+                    [<$sub_short _len>]: usize,
+                ) -> [<$sub IterMut>]<'a, T> {
+                    [<$sub IterMut>] {
+                        iter: self.0.chunks_exact_mut([<$sub_short _len>])
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_basic_operation_single_modulus {
+    ($cipher:ident < $s:ident >) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Perform element-wise modular addition `self + rhs`.
+            #[inline]
+            pub fn add_element_wise<M, A>(mut self, rhs: &$cipher<A>, modulus: M) -> Self
+            where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                ArrayBase(self.as_mut()).add_element_wise_assign(&ArrayBase(rhs.as_ref()), modulus);
+                self
+            }
+
+            /// Perform element-wise modular subtraction `self - rhs`.
+            #[inline]
+            pub fn sub_element_wise<M, A>(mut self, rhs: &$cipher<A>, modulus: M) -> Self
+            where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                ArrayBase(self.as_mut()).sub_element_wise_assign(&ArrayBase(rhs.as_ref()), modulus);
+                self
+            }
+
+            /// Performs an element-wise modular addition assignment `self += rhs`.
+            #[inline]
+            pub fn add_element_wise_assign<M, A>(&mut self, rhs: &$cipher<A>, modulus: M)
+            where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                ArrayBase(self.as_mut()).add_element_wise_assign(&ArrayBase(rhs.as_ref()), modulus);
+            }
+
+            /// Performs an element-wise modular subtraction assignment `self -= rhs`
+            #[inline]
+            pub fn sub_element_wise_assign<M, A>(&mut self, rhs: &$cipher<A>, modulus: M)
+            where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                ArrayBase(self.as_mut()).sub_element_wise_assign(&ArrayBase(rhs.as_ref()), modulus);
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Performs in-place element-wise modular addition:`result = self + rhs`,
+            #[inline]
+            pub fn add_element_wise_to<M, A, B>(
+                &self,
+                rhs: &$cipher<A>,
+                result: &mut $cipher<B>,
+                modulus: M,
+            ) where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+                B: RawData<Elem = T> + DataMut,
+            {
+                ArrayBase(self.as_ref()).add_element_wise_to(
+                    &ArrayBase(rhs.as_ref()),
+                    &mut ArrayBase(result.as_mut()),
+                    modulus,
+                )
+            }
+
+            /// Performs in-place element-wise modular addition:`result = self - rhs`,
+            #[inline]
+            pub fn sub_element_wise_to<M, A, B>(
+                &self,
+                rhs: &$cipher<A>,
+                result: &mut $cipher<B>,
+                modulus: M,
+            ) where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+                B: RawData<Elem = T> + DataMut,
+            {
+                ArrayBase(self.as_ref()).sub_element_wise_to(
+                    &ArrayBase(rhs.as_ref()),
+                    &mut ArrayBase(result.as_mut()),
+                    modulus,
+                )
+            }
+        }
+    };
+}
+
+macro_rules! impl_basic_operation_multiple_modulus {
+    ($cipher:ident < $s:ident >) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Perform element-wise modular addition `self + rhs`.
+            #[inline]
+            pub fn add_element_wise<M, A>(
+                mut self,
+                rhs: &$cipher<A>,
+                poly_length: usize,
+                crt_poly_length: usize,
+                moduli: &[M],
+            ) -> Self
+            where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                self.add_element_wise_assign(rhs, poly_length, crt_poly_length, moduli);
+                self
+            }
+
+            /// Perform element-wise modular subtraction `self - rhs`.
+            #[inline]
+            pub fn sub_element_wise<M, A>(
+                mut self,
+                rhs: &$cipher<A>,
+                poly_length: usize,
+                crt_poly_length: usize,
+                moduli: &[M],
+            ) -> Self
+            where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                self.sub_element_wise_assign(rhs, poly_length, crt_poly_length, moduli);
+                self
+            }
+
+            /// Performs an element-wise modular addition assignment `self += rhs`.
+            #[inline]
+            pub fn add_element_wise_assign<M, A>(
+                &mut self,
+                rhs: &$cipher<A>,
+                poly_length: usize,
+                crt_poly_length: usize,
+                moduli: &[M],
+            ) where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                izip!(
+                    self.0.chunks_exact_mut(crt_poly_length),
+                    rhs.0.chunks_exact(crt_poly_length),
+                )
+                .for_each(|(x, y)| {
+                    izip!(
+                        x.chunks_exact_mut(poly_length),
+                        y.chunks_exact(poly_length),
+                        moduli
+                    )
+                    .for_each(|(a, b, &modulus)| {
+                        ArrayBase(a).add_element_wise_assign(&ArrayBase(b), modulus);
+                    });
+                });
+            }
+
+            /// Performs an element-wise modular subtraction assignment `self -= rhs`.
+            #[inline]
+            pub fn sub_element_wise_assign<M, A>(
+                &mut self,
+                rhs: &$cipher<A>,
+                poly_length: usize,
+                crt_poly_length: usize,
+                moduli: &[M],
+            ) where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+            {
+                izip!(
+                    self.0.chunks_exact_mut(crt_poly_length),
+                    rhs.0.chunks_exact(crt_poly_length),
+                )
+                .for_each(|(x, y)| {
+                    izip!(
+                        x.chunks_exact_mut(poly_length),
+                        y.chunks_exact(poly_length),
+                        moduli
+                    )
+                    .for_each(|(a, b, &modulus)| {
+                        ArrayBase(a).sub_element_wise_assign(&ArrayBase(b), modulus);
+                    });
+                });
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Performs element-wise modular addition `result = self + rhs`.
+            #[inline]
+            pub fn add_element_wise_to<M, A, B>(
+                &self,
+                rhs: &$cipher<A>,
+                result: &mut $cipher<B>,
+                poly_length: usize,
+                crt_poly_length: usize,
+                moduli: &[M],
+            ) where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+                B: RawData<Elem = T> + DataMut,
+            {
+                izip!(
+                    self.0.chunks_exact(crt_poly_length),
+                    rhs.0.chunks_exact(crt_poly_length),
+                    result.0.chunks_exact_mut(crt_poly_length),
+                )
+                .for_each(|(x, y, z)| {
+                    izip!(
+                        x.chunks_exact(poly_length),
+                        y.chunks_exact(poly_length),
+                        z.chunks_exact_mut(poly_length),
+                        moduli
+                    )
+                    .for_each(|(a, b, c, &modulus)| {
+                        ArrayBase(a).add_element_wise_to(&ArrayBase(b), &mut ArrayBase(c), modulus);
+                    });
+                });
+            }
+
+            /// Performs element-wise modular subtraction `result = self - rhs`.
+            #[inline]
+            pub fn sub_element_wise_to<M, A, B>(
+                &self,
+                rhs: &$cipher<A>,
+                result: &mut $cipher<B>,
+                poly_length: usize,
+                crt_poly_length: usize,
+                moduli: &[M],
+            ) where
+                M: FieldContext<T>,
+                A: RawData<Elem = T> + Data,
+                B: RawData<Elem = T> + DataMut,
+            {
+                izip!(
+                    self.0.chunks_exact(crt_poly_length),
+                    rhs.0.chunks_exact(crt_poly_length),
+                    result.0.chunks_exact_mut(crt_poly_length),
+                )
+                .for_each(|(x, y, z)| {
+                    izip!(
+                        x.chunks_exact(poly_length),
+                        y.chunks_exact(poly_length),
+                        z.chunks_exact_mut(poly_length),
+                        moduli
+                    )
+                    .for_each(|(a, b, c, &modulus)| {
+                        ArrayBase(a).sub_element_wise_to(&ArrayBase(b), &mut ArrayBase(c), modulus);
+                    });
+                });
+            }
+        }
+    };
+}
+
+macro_rules! impl_ntt {
+    ($cipher:ident < $s:ident >,$ntt_cipher:ident) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Transforms `self` to ntt form.
+            #[inline]
+            pub fn into_ntt_form<Table>(mut self, ntt_table: &Table) -> $ntt_cipher<S>
+            where
+                Table: NttTable<ValueT = T>,
+            {
+                let poly_length = ntt_table.poly_length();
+                self.0.chunks_exact_mut(poly_length).for_each(|poly| {
+                    ntt_table.transform_slice(poly);
+                });
+                $ntt_cipher::new(self.0)
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Transforms `self` to ntt form and stores in `result`.
+            #[inline]
+            pub fn write_ntt_form<Table, A>(&self, result: &mut $ntt_cipher<A>, ntt_table: &Table)
+            where
+                A: RawData<Elem = T> + DataMut,
+                Table: NttTable<ValueT = T>,
+            {
+                let poly_length = ntt_table.poly_length();
+                result.0.copy_from_slice(self.as_ref());
+                result.0.chunks_exact_mut(poly_length).for_each(|poly| {
+                    ntt_table.transform_slice(poly);
+                });
+            }
+        }
+    };
+}
+
+macro_rules! impl_intt {
+    ($ntt_cipher:ident < $s:ident >,$cipher:ident) => {
+        impl<$s, T> $ntt_cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Transforms `self` to coefficient form.
+            #[inline]
+            pub fn into_coeff_form<Table>(mut self, ntt_table: &Table) -> $cipher<S>
+            where
+                Table: NttTable<ValueT = T>,
+            {
+                let poly_length = ntt_table.poly_length();
+                self.0.chunks_exact_mut(poly_length).for_each(|poly| {
+                    ntt_table.inverse_transform_slice(poly);
+                });
+                $cipher::new(self.0)
+            }
+        }
+
+        impl<$s, T> $ntt_cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Transforms `self` to coefficient form and stores in `result`.
+            #[inline]
+            pub fn write_coeff_form<Table, A>(&self, result: &mut $cipher<A>, ntt_table: &Table)
+            where
+                A: RawData<Elem = T> + DataMut,
+                Table: NttTable<ValueT = T>,
+            {
+                let poly_length = ntt_table.poly_length();
+                result.0.copy_from_slice(self.as_ref());
+                result.0.chunks_exact_mut(poly_length).for_each(|values| {
+                    ntt_table.inverse_transform_slice(values);
+                });
+            }
+        }
+    };
+}
+
+macro_rules! impl_crt_ntt {
+    ($cipher:ident < $s:ident >,$ntt_cipher:ident) => {
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Transforms `self` to ntt form.
+            #[inline]
+            pub fn into_ntt_form<Table>(self, table: &Table) -> $ntt_cipher<$s>
+            where
+                Table: DcrtTable<ValueT = T>,
+            {
+                let crt_poly_length = table.crt_poly_length();
+                let Self(mut data) = self;
+                data.chunks_exact_mut(crt_poly_length).for_each(|crt_poly| {
+                    table.transform_slice(crt_poly);
+                });
+                $ntt_cipher::new(data)
+            }
+        }
+
+        impl<$s, T> $cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Transforms `self` to ntt form and stores in `result`.
+            #[inline]
+            pub fn write_ntt_form<Table, A>(&self, result: &mut $ntt_cipher<A>, table: &Table)
+            where
+                Table: DcrtTable<ValueT = T>,
+                A: RawData<Elem = T> + DataMut,
+            {
+                let crt_poly_length = table.crt_poly_length();
+                result.0.copy_from_slice(self.as_ref());
+                result
+                    .0
+                    .chunks_exact_mut(crt_poly_length)
+                    .for_each(|crt_poly| {
+                        table.transform_slice(crt_poly);
+                    });
+            }
+        }
+    };
+}
+
+macro_rules! impl_crt_intt {
+    ($ntt_cipher:ident < $s:ident >,$cipher:ident) => {
+        impl<$s, T> $ntt_cipher<$s>
+        where
+            $s: RawData<Elem = T> + DataMut,
+            T: FheUint,
+        {
+            /// Transforms `self` to coefficient form.
+            #[inline]
+            pub fn into_coeff_form<Table>(self, table: &Table) -> $cipher<$s>
+            where
+                Table: DcrtTable<ValueT = T>,
+            {
+                let crt_poly_length = table.crt_poly_length();
+                let Self(mut data) = self;
+                data.chunks_exact_mut(crt_poly_length).for_each(|crt_poly| {
+                    table.inverse_transform_slice(crt_poly);
+                });
+                $cipher::new(data)
+            }
+        }
+
+        impl<$s, T> $ntt_cipher<$s>
+        where
+            $s: RawData<Elem = T> + Data,
+            T: FheUint,
+        {
+            /// Transforms `self` to coefficient form and stores in `result`.
+            #[inline]
+            pub fn write_coeff_form<Table, A>(&self, result: &mut $cipher<A>, table: &Table)
+            where
+                Table: DcrtTable<ValueT = T>,
+                A: RawData<Elem = T> + DataMut,
+            {
+                let crt_poly_length = table.crt_poly_length();
+                result.0.copy_from_slice(self.as_ref());
+                result
+                    .0
+                    .chunks_exact_mut(crt_poly_length)
+                    .for_each(|crt_poly| {
+                        table.inverse_transform_slice(crt_poly);
+                    });
+            }
+        }
+    };
+}

--- a/crates/primus_lattice/src/ntru/coeff.rs
+++ b/crates/primus_lattice/src/ntru/coeff.rs
@@ -85,6 +85,7 @@ where
     S: RawData<Elem = T> + DataMut,
     T: FheUint,
 {
+    /// Multiplies each coefficient by `scalar` modulo `modulus` in place.
     #[inline]
     pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
     where
@@ -93,6 +94,7 @@ where
         ArrayBase(self.as_mut()).mul_scalar_assign(scalar, modulus);
     }
 
+    /// Multiplies each coefficient by a Shoup `factor` modulo `modulus` in place.
     #[inline]
     pub fn mul_factor_assign<F>(&mut self, factor: F, modulus: T)
     where

--- a/crates/primus_lattice/src/ntru/coeff.rs
+++ b/crates/primus_lattice/src/ntru/coeff.rs
@@ -1,0 +1,113 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_factor::FactorSliceOps;
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial, Polynomial};
+use primus_reduce::FieldContext;
+
+use super::NttNtru;
+
+/// A cryptographic structure for NTRU.
+///
+/// ## Structure of the `data`
+///
+/// |------h------|
+///
+/// where `h` is [`Polynomial`].
+#[derive(Clone)]
+pub struct Ntru<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Ntru<S>);
+impl_bytes_conversion!(Ntru<S>);
+impl_zero!(Ntru<S>);
+impl_iters!(Ntru);
+impl_basic_operation_single_modulus!(Ntru<S>);
+
+impl<S, T> Ntru<S>
+where
+    S: RawData<Elem = T> + DataOwned,
+    T: FheUint,
+{
+    /// Creates a new [`Ntru<S>`] with reference of [`Polynomial<A>`].
+    #[inline]
+    pub fn from_ref<A>(h: &Polynomial<A>) -> Self
+    where
+        A: RawData<Elem = T> + Data,
+    {
+        Self(S::from_vec(h.as_ref().to_vec()))
+    }
+}
+
+impl<S, T> Ntru<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Transforms `self` to ntt form and stores in `result`.
+    #[inline]
+    pub fn write_ntt_form<Table, A>(&self, result: &mut NttNtru<A>, ntt_table: &Table)
+    where
+        A: RawData<Elem = T> + DataMut,
+        Table: NttTable<ValueT = T>,
+    {
+        let p = result.as_mut();
+        p.copy_from_slice(self.as_ref());
+        ntt_table.transform_slice(p)
+    }
+
+    /// Performs a multiplication on the `self` [`Ntru<S>`] with another `ntt_polynomial` [`NttPolynomial<A>`],
+    /// store the result into `result` [`NttNtru<B>`].
+    #[inline]
+    pub fn mul_ntt_polynomial_to<M, Table, A, B>(
+        &self,
+        ntt_poly: &NttPolynomial<A>,
+        result: &mut NttNtru<B>,
+        modulus: M,
+        ntt_table: &Table,
+    ) where
+        M: FieldContext<T>,
+        Table: NttTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let p = result.as_mut();
+        p.copy_from_slice(self.as_ref());
+        ntt_table.transform_slice(p);
+        NttPolynomial(p).mul_assign(ntt_poly, modulus);
+    }
+}
+
+impl<S, T> Ntru<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    #[inline]
+    pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
+    where
+        M: FieldContext<T>,
+    {
+        ArrayBase(self.as_mut()).mul_scalar_assign(scalar, modulus);
+    }
+
+    #[inline]
+    pub fn mul_factor_assign<F>(&mut self, factor: F, modulus: T)
+    where
+        F: FactorSliceOps<T>,
+    {
+        ArrayBase(self.as_mut()).mul_factor_assign(factor, modulus);
+    }
+
+    /// Transforms `self` to ntt form.
+    #[inline]
+    pub fn into_ntt_form<Table>(mut self, ntt_table: &Table) -> NttNtru<S>
+    where
+        Table: NttTable<ValueT = T>,
+    {
+        ntt_table.transform_slice(self.as_mut());
+        NttNtru::new(self.0)
+    }
+}

--- a/crates/primus_lattice/src/ntru/mod.rs
+++ b/crates/primus_lattice/src/ntru/mod.rs
@@ -1,0 +1,5 @@
+mod coeff;
+mod ntt;
+
+pub use coeff::{Ntru, NtruIter, NtruIterMut};
+pub use ntt::{NttNtru, NttNtruIter, NttNtruIterMut};

--- a/crates/primus_lattice/src/ntru/ntt.rs
+++ b/crates/primus_lattice/src/ntru/ntt.rs
@@ -1,0 +1,111 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial};
+use primus_reduce::FieldContext;
+
+use super::Ntru;
+
+/// A cryptographic structure for NTRU.
+///
+/// ## Structure of the `data`
+///
+/// |------h------|
+///
+/// where `h` is [`NttPolynomial`].
+#[derive(Clone)]
+pub struct NttNtru<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttNtru<S>);
+impl_bytes_conversion!(NttNtru<S>);
+impl_zero!(NttNtru<S>);
+impl_iters!(NttNtru);
+impl_basic_operation_single_modulus!(NttNtru<S>);
+
+impl<S, T> NttNtru<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Transforms `self` to coefficient form and stores in `result`.
+    #[inline]
+    pub fn write_coeff_form<Table, A>(&self, result: &mut Ntru<A>, ntt_table: &Table)
+    where
+        A: RawData<Elem = T> + DataMut,
+        Table: NttTable<ValueT = T>,
+    {
+        let p = result.as_mut();
+        p.copy_from_slice(self.as_ref());
+        ntt_table.inverse_transform_slice(p);
+    }
+
+    /// Performs a modular multiplication on the `self` [`NttNtru<S>`] with another `polynomial` [`NttPolynomial`],
+    /// stores the result into `result`.
+    #[inline]
+    pub fn mul_ntt_polynomial_to<M, A, B>(
+        &self,
+        ntt_poly: &NttPolynomial<A>,
+        result: &mut NttNtru<B>,
+        modulus: M,
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        NttPolynomial(self.as_ref()).mul_to(ntt_poly, &mut NttPolynomial(result.as_mut()), modulus);
+    }
+}
+
+impl<S, T> NttNtru<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Transforms `self` to coefficient form.
+    #[inline]
+    pub fn into_coeff_form<Table>(mut self, ntt_table: &Table) -> Ntru<S>
+    where
+        Table: NttTable<ValueT = T>,
+    {
+        ntt_table.inverse_transform_slice(self.as_mut());
+        Ntru::new(self.0)
+    }
+
+    #[inline]
+    pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
+    where
+        M: FieldContext<T>,
+    {
+        ArrayBase(self.as_mut()).mul_scalar_assign(scalar, modulus);
+    }
+
+    /// Performs a modular multiplication on the `self` [`NttNtru<S>`] with another `ntt_poly` [`NttPolynomial<A>`].
+    #[inline]
+    pub fn mul_ntt_polynomial_assign<M, A>(&mut self, ntt_poly: &NttPolynomial<A>, modulus: M)
+    where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        NttPolynomial(self.as_mut()).mul_assign(ntt_poly, modulus);
+    }
+
+    pub fn add_ntt_ntru_mul_ntt_polynomial_assign<M, A, B>(
+        &mut self,
+        ntt_ntru: &NttNtru<A>,
+        ntt_poly: &NttPolynomial<B>,
+        modulus: M,
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + Data,
+    {
+        NttPolynomial(self.as_mut()).add_mul_assign(
+            &NttPolynomial(ntt_ntru.as_ref()),
+            ntt_poly,
+            modulus,
+        );
+    }
+}

--- a/crates/primus_lattice/src/ntru/ntt.rs
+++ b/crates/primus_lattice/src/ntru/ntt.rs
@@ -74,6 +74,7 @@ where
         Ntru::new(self.0)
     }
 
+    /// Multiplies each NTT coefficient by `scalar` modulo `modulus` in place.
     #[inline]
     pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
     where
@@ -92,6 +93,7 @@ where
         NttPolynomial(self.as_mut()).mul_assign(ntt_poly, modulus);
     }
 
+    /// Performs `self += ntt_ntru * ntt_poly` in place, all in the NTT domain.
     pub fn add_ntt_ntru_mul_ntt_polynomial_assign<M, A, B>(
         &mut self,
         ntt_ntru: &NttNtru<A>,

--- a/crates/primus_lattice/src/rgsw/coeff.rs
+++ b/crates/primus_lattice/src/rgsw/coeff.rs
@@ -1,0 +1,30 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlev::{RlevIter, RlevIterMut};
+
+use super::NttRgsw;
+
+/// Represents a ciphertext in the Ring-GSW (Ring Learning With Errors) homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::rlev::Rlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct Rgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Rgsw<S>);
+impl_bytes_conversion!(Rgsw<S>);
+impl_zero!(Rgsw<S>);
+impl_iters!(Rgsw);
+impl_iter_sub_structure!(Rgsw<S>, Rlev);
+impl_basic_operation_single_modulus!(Rgsw<S>);
+impl_ntt!(Rgsw<S>, NttRgsw);

--- a/crates/primus_lattice/src/rgsw/crt.rs
+++ b/crates/primus_lattice/src/rgsw/crt.rs
@@ -1,0 +1,31 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlev::{CrtRlevIter, CrtRlevIterMut};
+
+use super::DcrtRgsw;
+
+/// Represents a ciphertext in the Ring-GSW (Ring Learning With Errors) homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::rlev::CrtRlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct CrtRgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(CrtRgsw<S>);
+impl_bytes_conversion!(CrtRgsw<S>);
+impl_zero!(CrtRgsw<S>);
+impl_iters!(CrtRgsw);
+impl_iter_sub_structure!(CrtRgsw<S>, CrtRlev);
+impl_basic_operation_multiple_modulus!(CrtRgsw<S>);
+impl_crt_ntt!(CrtRgsw<S>, DcrtRgsw);

--- a/crates/primus_lattice/src/rgsw/dcrt.rs
+++ b/crates/primus_lattice/src/rgsw/dcrt.rs
@@ -1,0 +1,31 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlev::{DcrtRlevIter, DcrtRlevIterMut};
+
+use super::CrtRgsw;
+
+/// Represents a ciphertext in the Ring-GSW (Ring Learning With Errors) homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::rlev::DcrtRlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct DcrtRgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(DcrtRgsw<S>);
+impl_bytes_conversion!(DcrtRgsw<S>);
+impl_zero!(DcrtRgsw<S>);
+impl_iters!(DcrtRgsw);
+impl_iter_sub_structure!(DcrtRgsw<S>, DcrtRlev);
+impl_basic_operation_multiple_modulus!(DcrtRgsw<S>);
+impl_crt_intt!(DcrtRgsw<S>, CrtRgsw);

--- a/crates/primus_lattice/src/rgsw/mod.rs
+++ b/crates/primus_lattice/src/rgsw/mod.rs
@@ -1,0 +1,11 @@
+mod coeff;
+mod ntt;
+
+mod crt;
+mod dcrt;
+
+pub use coeff::{Rgsw, RgswIter, RgswIterMut};
+pub use ntt::{NttRgsw, NttRgswIter, NttRgswIterMut};
+
+pub use crt::{CrtRgsw, CrtRgswIter, CrtRgswIterMut};
+pub use dcrt::{DcrtRgsw, DcrtRgswIter, DcrtRgswIterMut};

--- a/crates/primus_lattice/src/rgsw/ntt.rs
+++ b/crates/primus_lattice/src/rgsw/ntt.rs
@@ -1,0 +1,30 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlev::{NttRlevIter, NttRlevIterMut};
+
+use super::Rgsw;
+
+/// Represents a ciphertext in the Ring-GSW (Ring Learning With Errors) homomorphic encryption scheme.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--ck--|--c[k+1]--|
+///
+/// where `c1` to `c[k+1]` are [`crate::rlev::NttRlev`] with same parameter, `k` is the dimension.
+#[derive(Clone)]
+pub struct NttRgsw<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttRgsw<S>);
+impl_bytes_conversion!(NttRgsw<S>);
+impl_zero!(NttRgsw<S>);
+impl_iters!(NttRgsw);
+impl_iter_sub_structure!(NttRgsw<S>, NttRlev);
+impl_basic_operation_single_modulus!(NttRgsw<S>);
+impl_intt!(NttRgsw<S>, Rgsw);

--- a/crates/primus_lattice/src/rlev/coeff.rs
+++ b/crates/primus_lattice/src/rlev/coeff.rs
@@ -1,0 +1,31 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlwe::{RlweIter, RlweIterMut};
+
+use super::NttRlev;
+
+/// A representation of Ring Learning with Errors (RLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::rlwe::Rlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct Rlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Rlev<S>);
+impl_bytes_conversion!(Rlev<S>);
+impl_zero!(Rlev<S>);
+impl_iters!(Rlev);
+impl_iter_sub_structure!(Rlev<S>, Rlwe);
+impl_basic_operation_single_modulus!(Rlev<S>);
+impl_ntt!(Rlev<S>, NttRlev);

--- a/crates/primus_lattice/src/rlev/crt.rs
+++ b/crates/primus_lattice/src/rlev/crt.rs
@@ -1,0 +1,32 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlwe::{CrtRlweIter, CrtRlweIterMut};
+
+use super::DcrtRlev;
+
+/// A representation of Ring Learning with Errors (RLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::rlwe::CrtRlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct CrtRlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(CrtRlev<S>);
+impl_bytes_conversion!(CrtRlev<S>);
+impl_zero!(CrtRlev<S>);
+impl_iters!(CrtRlev);
+impl_iter_sub_structure!(CrtRlev<S>, CrtRlwe);
+impl_basic_operation_multiple_modulus!(CrtRlev<S>);
+impl_crt_ntt!(CrtRlev<S>, DcrtRlev);

--- a/crates/primus_lattice/src/rlev/dcrt.rs
+++ b/crates/primus_lattice/src/rlev/dcrt.rs
@@ -1,0 +1,32 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlwe::{DcrtRlweIter, DcrtRlweIterMut};
+
+use super::CrtRlev;
+
+/// A representation of Ring Learning with Errors (RLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::rlwe::DcrtRlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct DcrtRlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(DcrtRlev<S>);
+impl_bytes_conversion!(DcrtRlev<S>);
+impl_zero!(DcrtRlev<S>);
+impl_iters!(DcrtRlev);
+impl_iter_sub_structure!(DcrtRlev<S>, DcrtRlwe);
+impl_basic_operation_multiple_modulus!(DcrtRlev<S>);
+impl_crt_intt!(DcrtRlev<S>, CrtRlev);

--- a/crates/primus_lattice/src/rlev/mod.rs
+++ b/crates/primus_lattice/src/rlev/mod.rs
@@ -1,0 +1,11 @@
+mod coeff;
+mod ntt;
+
+mod crt;
+mod dcrt;
+
+pub use coeff::{Rlev, RlevIter, RlevIterMut};
+pub use ntt::{NttRlev, NttRlevIter, NttRlevIterMut};
+
+pub use crt::{CrtRlev, CrtRlevIter, CrtRlevIterMut};
+pub use dcrt::{DcrtRlev, DcrtRlevIter, DcrtRlevIterMut};

--- a/crates/primus_lattice/src/rlev/ntt.rs
+++ b/crates/primus_lattice/src/rlev/ntt.rs
@@ -1,0 +1,31 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::ArrayBase;
+use primus_reduce::FieldContext;
+
+use crate::rlwe::{NttRlweIter, NttRlweIterMut};
+
+use super::Rlev;
+
+/// A representation of Ring Learning with Errors (RLWE) ciphertexts with respect to different base,
+/// used to control noise growth in polynomial multiplications.
+///
+/// ## Structure of the `data`
+///
+/// |--c1--|....|--cd--|
+///
+/// where `c1` to `cd` are [`crate::rlwe::NttRlwe`] with same parameter, `d` is the decompose length.
+#[derive(Clone)]
+pub struct NttRlev<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttRlev<S>);
+impl_bytes_conversion!(NttRlev<S>);
+impl_zero!(NttRlev<S>);
+impl_iters!(NttRlev);
+impl_iter_sub_structure!(NttRlev<S>, NttRlwe);
+impl_basic_operation_single_modulus!(NttRlev<S>);
+impl_intt!(NttRlev<S>, Rlev);

--- a/crates/primus_lattice/src/rlwe/coeff.rs
+++ b/crates/primus_lattice/src/rlwe/coeff.rs
@@ -12,6 +12,7 @@ use crate::lwe::{Lwe, MultiMsgLwe};
 
 use super::NttRlwe;
 
+/// An owned RLWE sample backed by a [`Vec<T>`].
 pub type RlweOwned<T> = Rlwe<Vec<T>>;
 
 /// A cryptographic structure for Ring Learning with Errors (RLWE).
@@ -132,6 +133,7 @@ where
         unsafe { self.0.split_at_mut_unchecked(mid) }
     }
 
+    /// Multiplies each coefficient of both `a` and `b` by `scalar` modulo `modulus` in place.
     #[inline]
     pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
     where
@@ -140,6 +142,7 @@ where
         ArrayBase(self.as_mut()).mul_scalar_assign(scalar, modulus);
     }
 
+    /// Multiplies each coefficient of both `a` and `b` by a Shoup `factor` modulo `modulus` in place.
     #[inline]
     pub fn mul_factor_assign<F>(&mut self, factor: F, modulus: T)
     where
@@ -223,7 +226,7 @@ where
         Lwe::new(unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) })
     }
 
-    /// Extract an LWE sample from RLWE.
+    /// Extracts a [`MultiMsgLwe`] with several encrypted messages from RLWE.
     #[inline]
     pub fn extract_first_few_lwe<M>(&self, count: usize, modulus: M) -> MultiMsgLwe<Vec<T>>
     where

--- a/crates/primus_lattice/src/rlwe/coeff.rs
+++ b/crates/primus_lattice/src/rlwe/coeff.rs
@@ -1,0 +1,286 @@
+use std::mem::MaybeUninit;
+
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_distr::DiscreteGaussian;
+use primus_factor::FactorSliceOps;
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial, Polynomial, PolynomialIter, PolynomialIterMut};
+use primus_reduce::{FieldContext, ReduceNeg, ReduceNegAssign, ReduceNegSlice};
+
+use crate::lwe::{Lwe, MultiMsgLwe};
+
+use super::NttRlwe;
+
+pub type RlweOwned<T> = Rlwe<Vec<T>>;
+
+/// A cryptographic structure for Ring Learning with Errors (RLWE).
+///
+/// ## Structure of the `data`
+///
+/// |------a------|------b------|
+///
+/// where `a` and `b` are [`Polynomial`] with same poly length.
+#[derive(Clone)]
+pub struct Rlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(Rlwe<S>);
+impl_bytes_conversion!(Rlwe<S>);
+impl_zero!(Rlwe<S>);
+impl_iters!(Rlwe);
+impl_iter_sub_structure!(Rlwe<S>, Polynomial, poly);
+impl_basic_operation_single_modulus!(Rlwe<S>);
+impl_ntt!(Rlwe<S>, NttRlwe);
+
+impl<S, T> Rlwe<S>
+where
+    S: RawData<Elem = T> + DataOwned,
+    T: FheUint,
+{
+    /// Creates a new [`Rlwe<S>`] with reference of [`Polynomial<A>`].
+    #[inline]
+    pub fn from_ref<A>(a: &Polynomial<A>, b: &Polynomial<A>) -> Self
+    where
+        A: RawData<Elem = T> + Data,
+    {
+        debug_assert_eq!(a.poly_length(), b.poly_length());
+        Self(S::from_vec([a.as_ref(), b.as_ref()].concat()))
+    }
+}
+
+impl<T: FheUint> Rlwe<Vec<T>> {
+    /// Extract an LWE sample from RLWE.
+    #[inline]
+    pub fn extract_lwe_locally<M>(self, modulus: M) -> Lwe<Vec<T>>
+    where
+        M: Copy + ReduceNegSlice<T>,
+    {
+        let mut data = self.0;
+
+        let poly_len = data.len() / 2;
+        data.truncate(poly_len + 1);
+
+        let chunk = &mut data[1..poly_len];
+
+        chunk.reverse();
+        modulus.reduce_neg_slice_assign(chunk);
+
+        Lwe::new(data)
+    }
+
+    /// Sample extract a [`MultiMsgLwe<T>`] with several encrypted messages.
+    pub fn extract_first_few_lwe_locally<M>(self, count: usize, modulus: M) -> MultiMsgLwe<Vec<T>>
+    where
+        M: Copy + ReduceNegSlice<T>,
+    {
+        let mut data = self.0;
+        let poly_len = data.len() / 2;
+
+        data.truncate(poly_len + count);
+
+        data[1..poly_len].reverse();
+        modulus.reduce_neg_slice_assign(&mut data[1..poly_len]);
+
+        MultiMsgLwe::new(data)
+    }
+
+    /// Generate a [`Rlwe<Vec<T>>`] sample which encrypts `0`.
+    pub fn generate_random_zero_sample<R, Table, M, A>(
+        secret_key: &NttPolynomial<A>,
+        gaussian: &DiscreteGaussian<T>,
+        ntt_table: &Table,
+        modulus: M,
+        rng: &mut R,
+    ) -> Self
+    where
+        R: rand::Rng + rand::CryptoRng,
+        Table: NttTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        M: FieldContext<T>,
+    {
+        let poly_length = secret_key.poly_length();
+
+        let mut data = Rlwe::zero(poly_length * 2);
+
+        let (a, b) = data.a_b_mut_slices();
+
+        Polynomial(&mut *a).random_assign(modulus, rng);
+
+        b.copy_from_slice(a);
+        ntt_table.transform_slice(b);
+        NttPolynomial(&mut *b).mul_assign(secret_key, modulus);
+        ntt_table.inverse_transform_slice(b);
+
+        Polynomial(b).add_random_gaussian_assign(gaussian, modulus, rng);
+
+        data
+    }
+}
+
+impl<S, T> Rlwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Extracts mutable slice of `a` and `b` of this [`Rlwe<S>`].
+    #[inline]
+    pub fn a_b_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        let mid = self.0.len() >> 1;
+        unsafe { self.0.split_at_mut_unchecked(mid) }
+    }
+
+    #[inline]
+    pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
+    where
+        M: FieldContext<T>,
+    {
+        ArrayBase(self.as_mut()).mul_scalar_assign(scalar, modulus);
+    }
+
+    #[inline]
+    pub fn mul_factor_assign<F>(&mut self, factor: F, modulus: T)
+    where
+        F: FactorSliceOps<T>,
+    {
+        ArrayBase(self.as_mut()).mul_factor_assign(factor, modulus);
+    }
+}
+
+impl<S, T> Rlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Extracts slice of `a` and `b` of this [`Rlwe<S>`].
+    #[inline]
+    pub fn a_b_slices(&self) -> (&[T], &[T]) {
+        let mid = self.0.len() >> 1;
+        unsafe { self.0.split_at_unchecked(mid) }
+    }
+
+    /// Performs a multiplication on the `self` [`Rlwe<S>`] with another `ntt_polynomial` [`NttPolynomial<A>`],
+    /// store the result into `result` [`NttRlwe<B>`].
+    #[inline]
+    pub fn mul_ntt_polynomial_to<M, Table, A, B>(
+        &self,
+        ntt_poly: &NttPolynomial<A>,
+        result: &mut NttRlwe<B>,
+        modulus: M,
+        ntt_table: &Table,
+    ) where
+        M: FieldContext<T>,
+        Table: NttTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_length = ntt_table.poly_length();
+
+        result.0.copy_from_slice(self.as_ref());
+
+        result.0.chunks_exact_mut(poly_length).for_each(|poly| {
+            ntt_table.transform_slice(poly);
+            NttPolynomial(poly).mul_assign(ntt_poly, modulus);
+        });
+    }
+
+    /// Extract an LWE sample from RLWE.
+    #[inline]
+    pub fn extract_lwe_with_index<M>(&self, index: usize, modulus: M) -> Lwe<Vec<T>>
+    where
+        M: Copy + ReduceNeg<T, Output = T>,
+    {
+        let poly_len = self.0.len() / 2;
+
+        assert!(index < poly_len);
+
+        let src = self.0.as_slice();
+        let split = index + 1;
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(poly_len + 1);
+        unsafe {
+            data.set_len(poly_len + 1);
+        }
+
+        data[..split]
+            .iter_mut()
+            .zip(src[..split].iter().rev())
+            .for_each(|(x, &y)| {
+                x.write(y);
+            });
+
+        data[split..poly_len]
+            .iter_mut()
+            .zip(src[split..poly_len].iter().rev())
+            .for_each(|(x, &y)| {
+                x.write(modulus.reduce_neg(y));
+            });
+
+        data[poly_len].write(src[poly_len + index]);
+
+        Lwe::new(unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) })
+    }
+
+    /// Extract an LWE sample from RLWE.
+    #[inline]
+    pub fn extract_first_few_lwe<M>(&self, count: usize, modulus: M) -> MultiMsgLwe<Vec<T>>
+    where
+        M: Copy + ReduceNeg<T, Output = T> + ReduceNegAssign<T>,
+    {
+        let poly_len = self.0.len() / 2;
+        let src = self.0.as_slice();
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(poly_len + count);
+        unsafe {
+            data.set_len(poly_len + count);
+        }
+
+        data[0].write(src[0]);
+
+        data[1..poly_len]
+            .iter_mut()
+            .zip(src[1..poly_len].iter().rev())
+            .for_each(|(x, &y)| {
+                x.write(modulus.reduce_neg(y));
+            });
+
+        data[poly_len..]
+            .iter_mut()
+            .zip(src[poly_len..].iter())
+            .for_each(|(x, &y)| {
+                x.write(y);
+            });
+
+        MultiMsgLwe::new(unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) })
+    }
+
+    /// Extract an LWE sample from RLWE.
+    #[inline]
+    pub fn extract_lwe<M>(&self, modulus: M) -> Lwe<Vec<T>>
+    where
+        M: Copy + ReduceNeg<T, Output = T> + ReduceNegAssign<T>,
+    {
+        let poly_len = self.0.len() / 2;
+        let src = self.0.as_slice();
+
+        let mut data: Vec<MaybeUninit<T>> = Vec::with_capacity(poly_len + 1);
+        unsafe {
+            data.set_len(poly_len + 1);
+        }
+
+        data[0].write(src[0]);
+
+        data[1..poly_len]
+            .iter_mut()
+            .zip(src[1..poly_len].iter().rev())
+            .for_each(|(x, &y)| {
+                x.write(modulus.reduce_neg(y));
+            });
+
+        data[poly_len].write(src[poly_len]);
+
+        Lwe::new(unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(data) })
+    }
+}

--- a/crates/primus_lattice/src/rlwe/crt.rs
+++ b/crates/primus_lattice/src/rlwe/crt.rs
@@ -1,0 +1,65 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::{ArrayBase, CrtPolynomialIter, CrtPolynomialIterMut, DcrtPolynomial};
+use primus_reduce::FieldContext;
+
+use super::DcrtRlwe;
+
+pub type CrtRlweOwned<T> = CrtRlwe<Vec<T>>;
+
+/// A cryptographic structure for Ring Learning with Errors (RLWE).
+///
+/// ## Structure of the `data`
+///
+/// |------a------|------b------|
+///
+/// where `a` and `b` are [`primus_poly::CrtPolynomial`] with same poly length and moduli count.
+#[derive(Clone)]
+pub struct CrtRlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(CrtRlwe<S>);
+impl_bytes_conversion!(CrtRlwe<S>);
+impl_zero!(CrtRlwe<S>);
+impl_iters!(CrtRlwe);
+impl_iter_sub_structure!(CrtRlwe<S>, CrtPolynomial, crt_poly);
+impl_basic_operation_multiple_modulus!(CrtRlwe<S>);
+impl_crt_ntt!(CrtRlwe<S>, DcrtRlwe);
+
+impl<S, T> CrtRlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Performs a multiplication on the `self` [`CrtRlwe<S>`] with another `dcrt_polynomial` [`DcrtPolynomial<A>`],
+    /// store the result into `result` [`DcrtRlwe<B>`].
+    #[inline]
+    pub fn mul_dcrt_polynomial_to<M, Table, A, B>(
+        &self,
+        dcrt_poly: &DcrtPolynomial<A>,
+        result: &mut DcrtRlwe<B>,
+        moduli: &[M],
+        table: &Table,
+    ) where
+        M: FieldContext<T>,
+        Table: DcrtTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_length = table.poly_length();
+        let crt_poly_len = table.crt_poly_length();
+
+        result.0.copy_from_slice(self.as_ref());
+
+        result
+            .iter_dcrt_poly_mut(crt_poly_len)
+            .for_each(|mut poly| {
+                table.transform_slice(poly.0);
+                poly.mul_assign(dcrt_poly, poly_length, moduli);
+            });
+    }
+}

--- a/crates/primus_lattice/src/rlwe/crt.rs
+++ b/crates/primus_lattice/src/rlwe/crt.rs
@@ -7,6 +7,7 @@ use primus_reduce::FieldContext;
 
 use super::DcrtRlwe;
 
+/// An owned CRT-domain RLWE sample backed by a [`Vec<T>`].
 pub type CrtRlweOwned<T> = CrtRlwe<Vec<T>>;
 
 /// A cryptographic structure for Ring Learning with Errors (RLWE).

--- a/crates/primus_lattice/src/rlwe/dcrt.rs
+++ b/crates/primus_lattice/src/rlwe/dcrt.rs
@@ -7,6 +7,7 @@ use primus_reduce::FieldContext;
 
 use super::CrtRlwe;
 
+/// An owned DCRT-domain RLWE sample backed by a [`Vec<T>`].
 pub type DcrtRlweOwned<T> = DcrtRlwe<Vec<T>>;
 
 /// A cryptographic structure for Ring Learning with Errors (RLWE).

--- a/crates/primus_lattice/src/rlwe/dcrt.rs
+++ b/crates/primus_lattice/src/rlwe/dcrt.rs
@@ -1,0 +1,60 @@
+use itertools::izip;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::DcrtTable;
+use primus_poly::{ArrayBase, DcrtPolynomial, DcrtPolynomialIter, DcrtPolynomialIterMut};
+use primus_reduce::FieldContext;
+
+use super::CrtRlwe;
+
+pub type DcrtRlweOwned<T> = DcrtRlwe<Vec<T>>;
+
+/// A cryptographic structure for Ring Learning with Errors (RLWE).
+///
+/// ## Structure of the `data`
+///
+/// |------a------|------b------|
+///
+/// where `a` and `b` are [`DcrtPolynomial`] with same poly length and moduli count.
+#[derive(Clone)]
+pub struct DcrtRlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(DcrtRlwe<S>);
+impl_bytes_conversion!(DcrtRlwe<S>);
+impl_zero!(DcrtRlwe<S>);
+impl_iters!(DcrtRlwe);
+impl_iter_sub_structure!(DcrtRlwe<S>, DcrtPolynomial, dcrt_poly);
+impl_basic_operation_multiple_modulus!(DcrtRlwe<S>);
+impl_crt_intt!(DcrtRlwe<S>, CrtRlwe);
+
+impl<S, T> DcrtRlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Performs a multiplication on the `self` [`DcrtRlwe<S>`] with another `dcrt_poly` [`DcrtPolynomial<A>`],
+    /// store the result into `result` [`DcrtRlwe<B>`].
+    #[inline]
+    pub fn mul_dcrt_polynomial_to<M, A, B>(
+        &self,
+        dcrt_poly: &DcrtPolynomial<A>,
+        result: &mut DcrtRlwe<B>,
+        poly_length: usize,
+        moduli: &[M],
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let dcrt_poly_len = dcrt_poly.dcrt_poly_length();
+
+        self.iter_dcrt_poly(dcrt_poly_len)
+            .zip(result.iter_dcrt_poly_mut(dcrt_poly_len))
+            .for_each(|(a, mut b)| {
+                a.mul_to(dcrt_poly, &mut b, poly_length, moduli);
+            });
+    }
+}

--- a/crates/primus_lattice/src/rlwe/mod.rs
+++ b/crates/primus_lattice/src/rlwe/mod.rs
@@ -1,0 +1,15 @@
+mod coeff;
+mod ntt;
+
+mod crt;
+mod dcrt;
+
+mod truncate;
+
+pub use coeff::{Rlwe, RlweIter, RlweIterMut, RlweOwned};
+pub use ntt::{NttRlwe, NttRlweIter, NttRlweIterMut, NttRlweOwned};
+
+pub use crt::{CrtRlwe, CrtRlweIter, CrtRlweIterMut, CrtRlweOwned};
+pub use dcrt::{DcrtRlwe, DcrtRlweIter, DcrtRlweIterMut, DcrtRlweOwned};
+
+pub use truncate::TruncatedRlwe;

--- a/crates/primus_lattice/src/rlwe/ntt.rs
+++ b/crates/primus_lattice/src/rlwe/ntt.rs
@@ -6,6 +6,7 @@ use primus_reduce::FieldContext;
 
 use super::Rlwe;
 
+/// An owned NTT-domain RLWE sample backed by a [`Vec<T>`].
 pub type NttRlweOwned<T> = NttRlwe<Vec<T>>;
 
 /// A cryptographic structure for Ring Learning with Errors (RLWE).
@@ -65,6 +66,7 @@ where
         (NttPolynomial(a), NttPolynomial(b))
     }
 
+    /// Multiplies each NTT coefficient of both `a` and `b` by `scalar` modulo `modulus` in place.
     #[inline]
     pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
     where
@@ -87,6 +89,7 @@ where
         });
     }
 
+    /// Performs `self += ntt_rlwe * ntt_poly` in place, all in the NTT domain.
     pub fn add_ntt_rlwe_mul_ntt_polynomial_assign<M, A, B>(
         &mut self,
         ntt_rlwe: &NttRlwe<A>,

--- a/crates/primus_lattice/src/rlwe/ntt.rs
+++ b/crates/primus_lattice/src/rlwe/ntt.rs
@@ -1,0 +1,150 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial, NttPolynomialIter, NttPolynomialIterMut};
+use primus_reduce::FieldContext;
+
+use super::Rlwe;
+
+pub type NttRlweOwned<T> = NttRlwe<Vec<T>>;
+
+/// A cryptographic structure for Ring Learning with Errors (RLWE).
+///
+/// ## Structure of the `data`
+///
+/// |------a------|------b------|
+///
+/// where `a` and `b` are [`NttPolynomial`] with same poly length.
+#[derive(Clone)]
+pub struct NttRlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(NttRlwe<S>);
+impl_bytes_conversion!(NttRlwe<S>);
+impl_zero!(NttRlwe<S>);
+impl_iters!(NttRlwe);
+impl_iter_sub_structure!(NttRlwe<S>, NttPolynomial, ntt_poly);
+impl_basic_operation_single_modulus!(NttRlwe<S>);
+impl_intt!(NttRlwe<S>, Rlwe);
+
+impl<S, T> NttRlwe<S>
+where
+    S: RawData<Elem = T> + DataOwned,
+    T: FheUint,
+{
+    /// Creates a new [`NttRlwe<S>`] with reference of [`NttPolynomial<A>`].
+    #[inline]
+    pub fn from_ref<A>(a: &NttPolynomial<A>, b: &NttPolynomial<A>) -> Self
+    where
+        A: RawData<Elem = T> + Data,
+    {
+        debug_assert_eq!(a.poly_length(), b.poly_length());
+        Self(S::from_vec([a.as_ref(), b.as_ref()].concat()))
+    }
+}
+
+impl<S, T> NttRlwe<S>
+where
+    S: RawData<Elem = T> + DataMut,
+    T: FheUint,
+{
+    /// Extracts mutable slice of `a` and `b` of this [`NttRlwe<S>`].
+    #[inline]
+    pub fn a_b_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        let mid = self.0.len() >> 1;
+        unsafe { self.0.split_at_mut_unchecked(mid) }
+    }
+
+    /// Extracts mutable slice of `a` and `b` of this [`NttRlwe<S>`].
+    #[inline]
+    pub fn a_b_mut(&mut self) -> (NttPolynomial<&mut [T]>, NttPolynomial<&mut [T]>) {
+        let mid = self.0.len() >> 1;
+        let (a, b) = unsafe { self.0.split_at_mut_unchecked(mid) };
+        (NttPolynomial(a), NttPolynomial(b))
+    }
+
+    #[inline]
+    pub fn mul_scalar_assign<M>(&mut self, scalar: T, modulus: M)
+    where
+        M: FieldContext<T>,
+    {
+        ArrayBase(self.as_mut()).mul_scalar_assign(scalar, modulus);
+    }
+
+    /// Performs a modular multiplication on the `self` [`NttRlwe<S>`] with another `ntt_poly` [`NttPolynomial<A>`].
+    #[inline]
+    pub fn mul_ntt_polynomial_assign<M, A>(&mut self, ntt_poly: &NttPolynomial<A>, modulus: M)
+    where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+    {
+        let poly_len = ntt_poly.poly_length();
+
+        self.iter_ntt_poly_mut(poly_len).for_each(|mut p| {
+            p.mul_assign(ntt_poly, modulus);
+        });
+    }
+
+    pub fn add_ntt_rlwe_mul_ntt_polynomial_assign<M, A, B>(
+        &mut self,
+        ntt_rlwe: &NttRlwe<A>,
+        ntt_poly: &NttPolynomial<B>,
+        modulus: M,
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + Data,
+    {
+        let poly_len = ntt_poly.poly_length();
+        self.iter_ntt_poly_mut(poly_len)
+            .zip(ntt_rlwe.iter_ntt_poly(poly_len))
+            .for_each(|(mut x, y)| {
+                x.add_mul_assign(&y, ntt_poly, modulus);
+            });
+    }
+}
+
+impl<S, T> NttRlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Extracts slice of `a` and `b` of this [`NttRlwe<S>`].
+    #[inline]
+    pub fn a_b_slices(&self) -> (&[T], &[T]) {
+        let mid = self.0.len() >> 1;
+        unsafe { self.0.split_at_unchecked(mid) }
+    }
+
+    /// Extracts `a` and `b` of this [`NttRlwe<S>`].
+    #[inline]
+    pub fn a_b(&self) -> (NttPolynomial<&[T]>, NttPolynomial<&[T]>) {
+        let mid = self.0.len() >> 1;
+        let (a, b) = unsafe { self.0.split_at_unchecked(mid) };
+        (NttPolynomial(a), NttPolynomial(b))
+    }
+
+    /// Performs a modular multiplication on the `self` [`NttRlwe<S>`] with another `polynomial` [`NttPolynomial`],
+    /// stores the result into `result`.
+    #[inline]
+    pub fn mul_ntt_polynomial_to<M, A, B>(
+        &self,
+        ntt_poly: &NttPolynomial<A>,
+        result: &mut NttRlwe<B>,
+        modulus: M,
+    ) where
+        M: FieldContext<T>,
+        A: RawData<Elem = T> + Data,
+        B: RawData<Elem = T> + DataMut,
+    {
+        let poly_len = ntt_poly.poly_length();
+
+        self.iter_ntt_poly(poly_len)
+            .zip(result.iter_ntt_poly_mut(poly_len))
+            .for_each(|(x, mut y)| {
+                x.mul_to(ntt_poly, &mut y, modulus);
+            });
+    }
+}

--- a/crates/primus_lattice/src/rlwe/truncate.rs
+++ b/crates/primus_lattice/src/rlwe/truncate.rs
@@ -1,0 +1,114 @@
+use primus_data::{Data, DataMut, DataOwned, RawData};
+use primus_distr::DiscreteGaussian;
+use primus_integer::FheUint;
+use primus_ntt::NttTable;
+use primus_poly::{ArrayBase, NttPolynomial, Polynomial};
+use primus_reduce::{FieldContext, ReduceNegSlice};
+use rand::distr::Uniform;
+
+use crate::lwe::{Lwe, MultiMsgLwe};
+
+use super::Rlwe;
+
+/// A cryptographic structure for Ring Learning with Errors (RLWE).
+#[derive(Clone)]
+pub struct TruncatedRlwe<S>(pub S)
+where
+    S: RawData,
+    <S as RawData>::Elem: FheUint;
+
+impl_common!(TruncatedRlwe<S>);
+impl_bytes_conversion!(TruncatedRlwe<S>);
+impl_zero!(TruncatedRlwe<S>);
+impl_basic_operation_single_modulus!(TruncatedRlwe<S>);
+
+impl<T> TruncatedRlwe<Vec<T>>
+where
+    T: FheUint,
+{
+    /// Extract an LWE sample from RLWE.
+    #[inline]
+    pub fn extract_lwe_locally<M>(self, poly_length: usize, modulus: M) -> Lwe<Vec<T>>
+    where
+        M: Copy + ReduceNegSlice<T>,
+    {
+        let mut data = self.0;
+
+        data.truncate(poly_length + 1);
+
+        data[1..poly_length].reverse();
+        modulus.reduce_neg_slice_assign(&mut data[1..poly_length]);
+
+        Lwe::new(data)
+    }
+
+    /// Sample extract a [`MultiMsgLwe<T>`] with several encrypted messages.
+    pub fn extract_first_few_lwe_locally<M>(
+        self,
+        count: usize,
+        poly_length: usize,
+        modulus: M,
+    ) -> MultiMsgLwe<Vec<T>>
+    where
+        M: Copy + ReduceNegSlice<T>,
+    {
+        let mut data = self.0;
+
+        data.truncate(poly_length + count);
+
+        data[1..poly_length].reverse();
+        modulus.reduce_neg_slice_assign(&mut data[1..poly_length]);
+
+        MultiMsgLwe::new(data)
+    }
+
+    /// Generate a [`TruncatedRlwe<Vec<T>>`] sample which encrypts `0`.
+    pub fn generate_random_zero_sample<R, Table, M, A>(
+        msg_count: usize,
+        secret_key: &NttPolynomial<A>,
+        uniform: Uniform<T>,
+        gaussian: &DiscreteGaussian<T>,
+        ntt_table: &Table,
+        modulus: M,
+        rng: &mut R,
+    ) -> Self
+    where
+        R: rand::Rng + rand::CryptoRng,
+        Table: NttTable<ValueT = T>,
+        A: RawData<Elem = T> + Data,
+        M: FieldContext<T>,
+    {
+        let poly_length = secret_key.poly_length();
+
+        let mut cipher = Rlwe::zero(poly_length * 2);
+
+        let (a, b) = cipher.a_b_mut_slices();
+
+        Polynomial(&mut *a).random_with_distribution_assign(&uniform, rng);
+
+        b.copy_from_slice(a);
+        ntt_table.transform_slice(b);
+        NttPolynomial(&mut *b).mul_assign(secret_key, modulus);
+        ntt_table.inverse_transform_slice(b);
+
+        Polynomial(b).add_random_gaussian_assign(gaussian, modulus, rng);
+
+        let mut data: Vec<T> = cipher.0;
+
+        data.truncate(poly_length + msg_count);
+
+        TruncatedRlwe(data)
+    }
+}
+
+impl<S, T> TruncatedRlwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: FheUint,
+{
+    /// Extracts slice of `a` and `b` of this [`TruncatedRlwe<S>`].
+    #[inline]
+    pub fn a_b_slices(&self, poly_length: usize) -> (&[T], &[T]) {
+        unsafe { self.0.split_at_unchecked(poly_length) }
+    }
+}

--- a/crates/primus_lattice/src/tfhe/convert.rs
+++ b/crates/primus_lattice/src/tfhe/convert.rs
@@ -1,3 +1,12 @@
+//! Coefficient ↔ Fourier domain conversion for GLWE, GLev, and GGSW
+//! ciphertexts.
+//!
+//! Each method iterates over the flat storage by polynomial-sized chunks
+//! and calls [`FftTable::forward_torus_slice`] or
+//! [`FftTable::inverse_torus_slice`] per chunk.
+//! The GLev/Ggsw variants chunk at the individual-polynomial level
+//! and do not need to know about sub-component boundaries.
+
 use num_complex::Complex64;
 use primus_data::{Data, DataMut, RawData};
 use primus_fft::{FftTable, TorusFftValue};

--- a/crates/primus_lattice/src/tfhe/convert.rs
+++ b/crates/primus_lattice/src/tfhe/convert.rs
@@ -19,9 +19,6 @@ where
     T: TorusFftValue,
 {
     /// Writes this coefficient-domain GLWE into a Fourier-domain [`FourierGlwe`].
-    ///
-    /// Each coefficient polynomial (chunked by `fft.poly_length()`) is forward-
-    /// transformed into a Fourier polynomial (chunked by `fft.fourier_length()`).
     #[inline]
     pub fn write_fourier_form<Table, A>(&self, result: &mut FourierGlwe<A>, fft: &Table)
     where
@@ -29,11 +26,10 @@ where
         A: RawData<Elem = Complex64> + DataMut,
     {
         for (coeff, fourier) in self
-            .as_ref()
-            .chunks_exact(fft.poly_length())
-            .zip(result.as_mut().chunks_exact_mut(fft.fourier_length()))
+            .iter_poly(fft.poly_length())
+            .zip(result.iter_fourier_poly_mut(fft.fourier_length()))
         {
-            fft.forward_torus_slice(coeff, fourier);
+            fft.forward_torus_slice(coeff.0, fourier.0);
         }
     }
 }
@@ -91,9 +87,6 @@ where
     S: RawData<Elem = Complex64> + Data,
 {
     /// Writes this Fourier-domain GLWE back into a coefficient-domain [`Glwe`].
-    ///
-    /// Each Fourier polynomial (chunked by `fft.fourier_length()`) is inverse-
-    /// transformed into a coefficient polynomial (chunked by `fft.poly_length()`).
     #[inline]
     pub fn write_torus_form<Table, A, T>(&self, result: &mut Glwe<A>, fft: &Table)
     where
@@ -102,11 +95,10 @@ where
         T: TorusFftValue,
     {
         for (fourier, coeff) in self
-            .as_ref()
-            .chunks_exact(fft.fourier_length())
-            .zip(result.as_mut().chunks_exact_mut(fft.poly_length()))
+            .iter_fourier_poly(fft.fourier_length())
+            .zip(result.iter_poly_mut(fft.poly_length()))
         {
-            fft.inverse_torus_slice(fourier, coeff);
+            fft.inverse_torus_slice(fourier.0, coeff.0);
         }
     }
 }

--- a/crates/primus_lattice/src/tfhe/convert.rs
+++ b/crates/primus_lattice/src/tfhe/convert.rs
@@ -1,0 +1,156 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, RawData};
+use primus_fft::{FftTable, TorusFftValue};
+
+use crate::ggsw::Ggsw;
+use crate::ggsw::fourier::FourierGgsw;
+use crate::glev::Glev;
+use crate::glev::fourier::FourierGlev;
+use crate::glwe::Glwe;
+use crate::glwe::fourier::FourierGlwe;
+
+// ---------------------------------------------------------------------------
+// Forward: coefficient (torus) → Fourier (Complex64)
+// ---------------------------------------------------------------------------
+
+impl<S, T> Glwe<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: TorusFftValue,
+{
+    /// Writes this coefficient-domain GLWE into a Fourier-domain [`FourierGlwe`].
+    ///
+    /// Each coefficient polynomial (chunked by `fft.poly_length()`) is forward-
+    /// transformed into a Fourier polynomial (chunked by `fft.fourier_length()`).
+    #[inline]
+    pub fn write_fourier_form<Table, A>(&self, result: &mut FourierGlwe<A>, fft: &Table)
+    where
+        Table: FftTable,
+        A: RawData<Elem = Complex64> + DataMut,
+    {
+        for (coeff, fourier) in self
+            .as_ref()
+            .chunks_exact(fft.poly_length())
+            .zip(result.as_mut().chunks_exact_mut(fft.fourier_length()))
+        {
+            fft.forward_torus_slice(coeff, fourier);
+        }
+    }
+}
+
+impl<S, T> Glev<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: TorusFftValue,
+{
+    /// Writes this coefficient-domain GLev into a Fourier-domain [`FourierGlev`].
+    #[inline]
+    pub fn write_fourier_form<Table, A>(&self, result: &mut FourierGlev<A>, fft: &Table)
+    where
+        Table: FftTable,
+        A: RawData<Elem = Complex64> + DataMut,
+    {
+        for (coeff, fourier) in self
+            .as_ref()
+            .chunks_exact(fft.poly_length())
+            .zip(result.as_mut().chunks_exact_mut(fft.fourier_length()))
+        {
+            fft.forward_torus_slice(coeff, fourier);
+        }
+    }
+}
+
+impl<S, T> Ggsw<S>
+where
+    S: RawData<Elem = T> + Data,
+    T: TorusFftValue,
+{
+    /// Writes this coefficient-domain GGSW into a Fourier-domain [`FourierGgsw`].
+    #[inline]
+    pub fn write_fourier_form<Table, A>(&self, result: &mut FourierGgsw<A>, fft: &Table)
+    where
+        Table: FftTable,
+        A: RawData<Elem = Complex64> + DataMut,
+    {
+        for (coeff, fourier) in self
+            .as_ref()
+            .chunks_exact(fft.poly_length())
+            .zip(result.as_mut().chunks_exact_mut(fft.fourier_length()))
+        {
+            fft.forward_torus_slice(coeff, fourier);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inverse: Fourier (Complex64) → coefficient (torus)
+// ---------------------------------------------------------------------------
+
+impl<S> FourierGlwe<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Writes this Fourier-domain GLWE back into a coefficient-domain [`Glwe`].
+    ///
+    /// Each Fourier polynomial (chunked by `fft.fourier_length()`) is inverse-
+    /// transformed into a coefficient polynomial (chunked by `fft.poly_length()`).
+    #[inline]
+    pub fn write_torus_form<Table, A, T>(&self, result: &mut Glwe<A>, fft: &Table)
+    where
+        Table: FftTable,
+        A: RawData<Elem = T> + DataMut,
+        T: TorusFftValue,
+    {
+        for (fourier, coeff) in self
+            .as_ref()
+            .chunks_exact(fft.fourier_length())
+            .zip(result.as_mut().chunks_exact_mut(fft.poly_length()))
+        {
+            fft.inverse_torus_slice(fourier, coeff);
+        }
+    }
+}
+
+impl<S> FourierGlev<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Writes this Fourier-domain GLev back into a coefficient-domain [`Glev`].
+    #[inline]
+    pub fn write_torus_form<Table, A, T>(&self, result: &mut Glev<A>, fft: &Table)
+    where
+        Table: FftTable,
+        A: RawData<Elem = T> + DataMut,
+        T: TorusFftValue,
+    {
+        for (fourier, coeff) in self
+            .as_ref()
+            .chunks_exact(fft.fourier_length())
+            .zip(result.as_mut().chunks_exact_mut(fft.poly_length()))
+        {
+            fft.inverse_torus_slice(fourier, coeff);
+        }
+    }
+}
+
+impl<S> FourierGgsw<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Writes this Fourier-domain GGSW back into a coefficient-domain [`Ggsw`].
+    #[inline]
+    pub fn write_torus_form<Table, A, T>(&self, result: &mut Ggsw<A>, fft: &Table)
+    where
+        Table: FftTable,
+        A: RawData<Elem = T> + DataMut,
+        T: TorusFftValue,
+    {
+        for (fourier, coeff) in self
+            .as_ref()
+            .chunks_exact(fft.fourier_length())
+            .zip(result.as_mut().chunks_exact_mut(fft.poly_length()))
+        {
+            fft.inverse_torus_slice(fourier, coeff);
+        }
+    }
+}

--- a/crates/primus_lattice/src/tfhe/external_product.rs
+++ b/crates/primus_lattice/src/tfhe/external_product.rs
@@ -1,0 +1,87 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, RawData};
+use primus_decompose::primitive::ApproxSignedBasis;
+use primus_fft::{FftTable, TorusFftValue};
+use primus_poly::FourierPolynomial;
+
+use crate::context::tfhe::TfheFftContext;
+use crate::ggsw::fourier::FourierGgsw;
+use crate::glwe::fourier::FourierGlwe;
+use crate::tfhe::TorusGlwe;
+
+/// TFHE external product: `output = input ⊡ key` in the Fourier domain.
+///
+/// Decomposes each polynomial of the input GLWE into signed digits, forward-FFTs
+/// each digit, multiplies by the corresponding Fourier GGSW row/level, and
+/// accumulates in the Fourier domain before inverse-FFT back to torus
+/// coefficients.
+///
+/// # GLWE dimension convention
+///
+/// `glwe_dimension` is the count of *mask* polynomials (`k`).  The total
+/// number of polynomials in a GLWE ciphertext is `glwe_dimension + 1`
+/// (k mask + 1 body).  This matches [`Lwe::dimension()`](crate::lwe::Lwe::dimension).
+///
+/// # Shape requirements
+///
+/// - `input`: `(glwe_dimension + 1) * poly_length` torus values
+/// - `key`: `(glwe_dimension + 1) * level * (glwe_dimension + 1) * fourier_length` complex values
+/// - `output`: `(glwe_dimension + 1) * poly_length` torus values
+pub fn external_product_to<T, Table, A, B, C>(
+    input: &TorusGlwe<A>,
+    key: &FourierGgsw<B>,
+    output: &mut TorusGlwe<C>,
+    basis: &ApproxSignedBasis<T>,
+    fft: &Table,
+    context: &mut TfheFftContext<T>,
+    glwe_dimension: usize,
+) where
+    T: TorusFftValue,
+    Table: FftTable,
+    A: RawData<Elem = T> + Data,
+    B: RawData<Elem = Complex64> + Data,
+    C: RawData<Elem = T> + DataMut,
+{
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+    let level = basis.decompose_length();
+    // Total polynomials = k mask + 1 body
+    let total_components = glwe_dimension + 1;
+
+    // Zero the accumulator
+    context.fourier_accumulator.fill(Complex64::new(0.0, 0.0));
+
+    // Process each input component (a1..ak, b), aligned with GGSW rows:
+    let glwe_fourier_len = total_components * fourier_len;
+    let glev_len = level * glwe_fourier_len;
+
+    for (coeff_poly, key_row) in input.iter_poly(poly_len).zip(key.iter_glev(glev_len)) {
+        // Step 1: extract initial carry bits
+        basis.init_carry_slice(coeff_poly.0, &mut context.carries);
+
+        // Step 2: for each decomposition level, aligned with key GLev levels
+        for (decomposer, key_glwe) in basis
+            .decompose_iter()
+            .zip(key_row.iter_glwe(glwe_fourier_len))
+        {
+            decomposer.decompose_slice_to(
+                coeff_poly.0,
+                &mut context.decomposed_poly,
+                &mut context.carries,
+            );
+
+            // Forward FFT the decomposed polynomial
+            fft.forward_torus_slice(&context.decomposed_poly, &mut context.decomposed_fourier);
+
+            let decomposed_poly = FourierPolynomial::new(context.decomposed_fourier.as_slice());
+            let mut acc_glwe = FourierGlwe::new(context.fourier_accumulator.as_mut_slice());
+
+            // Step 3: accumulator += decomposed * key_glwe
+            acc_glwe.add_mul_fourier_poly_assign(&decomposed_poly, &key_glwe);
+        }
+    }
+
+    // Inverse FFT: accumulator → output GLWE
+    let acc_glwe = FourierGlwe::new(context.fourier_accumulator.as_slice());
+    acc_glwe.write_torus_form(output, fft);
+}

--- a/crates/primus_lattice/src/tfhe/external_product.rs
+++ b/crates/primus_lattice/src/tfhe/external_product.rs
@@ -1,3 +1,9 @@
+//! TFHE external product in the Fourier domain.
+//!
+//! The external product multiplies a coefficient GLWE ciphertext by a
+//! Fourier-domain GGSW key using signed gadget decomposition, accumulation
+//! in the Fourier domain, and inverse FFT back to the coefficient domain.
+
 use num_complex::Complex64;
 use primus_data::{Data, DataMut, RawData};
 use primus_decompose::primitive::ApproxSignedBasis;

--- a/crates/primus_lattice/src/tfhe/mod.rs
+++ b/crates/primus_lattice/src/tfhe/mod.rs
@@ -4,6 +4,7 @@
 //! documentation of torus semantics — no new storage is created.
 
 pub mod convert;
+pub mod external_product;
 
 /// TFHE torus LWE ciphertext (coefficient domain).
 ///

--- a/crates/primus_lattice/src/tfhe/mod.rs
+++ b/crates/primus_lattice/src/tfhe/mod.rs
@@ -1,7 +1,9 @@
-//! TFHE semantic type aliases.
+//! TFHE semantic type aliases and coefficient ↔ Fourier conversion.
 //!
 //! These reuse existing coefficient ciphertext containers and serve as
 //! documentation of torus semantics — no new storage is created.
+
+pub mod convert;
 
 /// TFHE torus LWE ciphertext (coefficient domain).
 ///

--- a/crates/primus_lattice/src/tfhe/mod.rs
+++ b/crates/primus_lattice/src/tfhe/mod.rs
@@ -1,0 +1,26 @@
+//! TFHE semantic type aliases.
+//!
+//! These reuse existing coefficient ciphertext containers and serve as
+//! documentation of torus semantics — no new storage is created.
+
+/// TFHE torus LWE ciphertext (coefficient domain).
+///
+/// Layout: `[a_1, ..., a_k, b]` — `k` mask elements + 1 body element.
+pub type TorusLwe<S> = crate::lwe::Lwe<S>;
+
+/// TFHE torus GLWE ciphertext (coefficient domain).
+///
+/// Layout: `|--a1--| ... |--ak--|--b--|` where each `a_i` and `b` is a
+/// polynomial of degree `N-1`.
+pub type TorusGlwe<S> = crate::glwe::Glwe<S>;
+
+/// TFHE torus GLev ciphertext (coefficient domain).
+///
+/// List of [`TorusGlwe`] per gadget decomposition level.
+pub type TorusGlev<S> = crate::glev::Glev<S>;
+
+/// TFHE torus GGSW ciphertext (coefficient domain).
+///
+/// Matrix of [`TorusGlev`] ciphertexts, one per row (i.e. one per GLWE mask
+/// component plus one for the body).
+pub type TorusGgsw<S> = crate::ggsw::Ggsw<S>;

--- a/crates/primus_lattice/tests/fourier.rs
+++ b/crates/primus_lattice/tests/fourier.rs
@@ -1,0 +1,141 @@
+use num_complex::Complex64;
+use primus_lattice::ggsw::fourier::{FourierGgsw, FourierGgswIter, FourierGgswOwned};
+use primus_lattice::glev::fourier::{FourierGlev, FourierGlevIter, FourierGlevOwned};
+use primus_lattice::glwe::fourier::{FourierGlwe, FourierGlweIter, FourierGlweOwned};
+
+// ---------------------------------------------------------------------------
+// FourierGlwe tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fourier_glwe_new_and_zero() {
+    let glwe = FourierGlweOwned::zero(6);
+    assert_eq!(glwe.byte_count(), 6 * 16);
+}
+
+#[test]
+fn fourier_glwe_set_zero() {
+    let data = vec![Complex64::new(1.0, 2.0); 12];
+    let mut glwe = FourierGlwe::new(data);
+    glwe.set_zero();
+    assert!(glwe.as_ref().iter().all(|&x| x == Complex64::new(0.0, 0.0)));
+}
+
+#[test]
+fn fourier_glwe_a_b_slices() {
+    let flen = 3;
+    let k = 2;
+    let glwe_len = (k + 1) * flen;
+    let mid = k * flen;
+    let data = vec![Complex64::new(0.0, 0.0); glwe_len];
+    let glwe = FourierGlwe::new(data);
+    let (a, b) = glwe.a_b_slices(mid);
+    assert_eq!(a.len(), mid);
+    assert_eq!(b.len(), flen);
+}
+
+#[test]
+fn fourier_glwe_a_b_mut_slices() {
+    let flen = 2;
+    let k = 1;
+    let glwe_len = (k + 1) * flen;
+    let mid = k * flen;
+    let mut glwe = FourierGlweOwned::zero(glwe_len);
+    {
+        let (a, b) = glwe.a_b_mut_slices(mid);
+        a[0] = Complex64::new(1.0, 0.0);
+        b[0] = Complex64::new(2.0, 0.0);
+    }
+    assert_eq!(glwe.as_ref()[0], Complex64::new(1.0, 0.0));
+    assert_eq!(glwe.as_ref()[mid], Complex64::new(2.0, 0.0));
+}
+
+#[test]
+fn fourier_glwe_iter_fourier_poly() {
+    let data = vec![Complex64::new(1.0, 0.0); 4];
+    let glwe = FourierGlwe::new(data);
+    let polys: Vec<_> = glwe.iter_fourier_poly(2).collect();
+    assert_eq!(polys.len(), 2);
+    assert_eq!(polys[0].fourier_length(), 2);
+    assert_eq!(polys[1].fourier_length(), 2);
+}
+
+#[test]
+fn fourier_glwe_iterator() {
+    let glwe_len = 4;
+    let data = vec![Complex64::new(0.0, 0.0); 8];
+    let iter = FourierGlweIter::new(&data, glwe_len);
+    assert_eq!(iter.count(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// FourierGlev tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fourier_glev_new_and_zero() {
+    let glev = FourierGlevOwned::zero(36);
+    assert_eq!(glev.byte_count(), 36 * 16);
+}
+
+#[test]
+fn fourier_glev_set_zero() {
+    let data = vec![Complex64::new(1.0, 2.0); 18];
+    let mut glev = FourierGlev::new(data);
+    glev.set_zero();
+    assert!(glev.as_ref().iter().all(|&x| x == Complex64::new(0.0, 0.0)));
+}
+
+#[test]
+fn fourier_glev_iter_glwe() {
+    let glwe_len = 4;
+    let glev_len = 12;
+    let data = vec![Complex64::new(0.0, 0.0); glev_len];
+    let glev = FourierGlev::new(data);
+    let glwes: Vec<_> = glev.iter_glwe(glwe_len).collect();
+    assert_eq!(glwes.len(), 3);
+}
+
+#[test]
+fn fourier_glev_iterator() {
+    let glev_len = 12;
+    let data = vec![Complex64::new(0.0, 0.0); 24];
+    let iter = FourierGlevIter::new(&data, glev_len);
+    assert_eq!(iter.count(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// FourierGgsw tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fourier_ggsw_new_and_zero() {
+    let ggsw = FourierGgswOwned::zero(72);
+    assert_eq!(ggsw.byte_count(), 72 * 16);
+}
+
+#[test]
+fn fourier_ggsw_set_zero() {
+    let data = vec![Complex64::new(1.0, 2.0); 72];
+    let mut ggsw = FourierGgsw::new(data);
+    ggsw.set_zero();
+    assert!(ggsw.as_ref().iter().all(|&x| x == Complex64::new(0.0, 0.0)));
+}
+
+#[test]
+fn fourier_ggsw_iter_glev() {
+    let glev_len = 8;
+    let ggsw_len = 16;
+    let data = vec![Complex64::new(0.0, 0.0); ggsw_len];
+    let ggsw = FourierGgsw::new(data);
+    let glevs: Vec<_> = ggsw.iter_glev(glev_len).collect();
+    assert_eq!(glevs.len(), 2);
+}
+
+#[test]
+fn fourier_ggsw_iterator() {
+    let ggsw_len = 16;
+    let data = vec![Complex64::new(0.0, 0.0); 32];
+    let iter = FourierGgswIter::new(&data, ggsw_len);
+    assert_eq!(iter.count(), 2);
+}

--- a/crates/primus_lattice/tests/fourier_convert.rs
+++ b/crates/primus_lattice/tests/fourier_convert.rs
@@ -1,0 +1,218 @@
+use primus_fft::{FftTable, FullComplex64FftTable};
+use primus_lattice::ggsw::Ggsw;
+use primus_lattice::ggsw::fourier::FourierGgswOwned;
+use primus_lattice::glev::Glev;
+use primus_lattice::glev::fourier::FourierGlevOwned;
+use primus_lattice::glwe::Glwe;
+use primus_lattice::glwe::fourier::FourierGlweOwned;
+
+// ---------------------------------------------------------------------------
+// GLWE roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_glwe_u32() {
+    for log_n in 1..=4 {
+        let fft = FullComplex64FftTable::new(log_n).unwrap();
+        let poly_len = fft.poly_length();
+        let fourier_len = fft.fourier_length();
+
+        let k = 2;
+        let glwe_len = (k + 1) * poly_len;
+        let fourier_glwe_len = (k + 1) * fourier_len;
+
+        // Coefficient GLWE with small centered values
+        let coeff: Vec<u32> = (0..glwe_len)
+            .map(|i| match i % 5 {
+                0 => 0u32,
+                1 => 1u32,
+                2 => (-1i32) as u32,
+                3 => 2u32,
+                _ => (-2i32) as u32,
+            })
+            .collect();
+        let glwe = Glwe::new(coeff.clone());
+
+        // Forward: coeff → Fourier
+        let mut fourier_glwe = FourierGlweOwned::zero(fourier_glwe_len);
+        glwe.write_fourier_form(&mut fourier_glwe, &fft);
+
+        // Inverse: Fourier → coeff
+        let mut result = Glwe::<Vec<u32>>::zero(glwe_len);
+        fourier_glwe.write_torus_form(&mut result, &fft);
+
+        assert_eq!(
+            coeff,
+            result.as_ref(),
+            "GLWE u32 roundtrip failed for log_n={log_n}"
+        );
+    }
+}
+
+#[test]
+fn roundtrip_glwe_u64() {
+    for log_n in 1..=3 {
+        let fft = FullComplex64FftTable::new(log_n).unwrap();
+        let poly_len = fft.poly_length();
+        let fourier_len = fft.fourier_length();
+
+        let k = 1;
+        let glwe_len = (k + 1) * poly_len;
+        let fourier_glwe_len = (k + 1) * fourier_len;
+
+        let coeff: Vec<u64> = (0..glwe_len)
+            .map(|i| match i % 5 {
+                0 => 0u64,
+                1 => 1u64,
+                2 => (-1i64) as u64,
+                3 => 2u64,
+                _ => (-2i64) as u64,
+            })
+            .collect();
+        let glwe = Glwe::new(coeff.clone());
+
+        let mut fourier_glwe = FourierGlweOwned::zero(fourier_glwe_len);
+        glwe.write_fourier_form(&mut fourier_glwe, &fft);
+
+        let mut result = Glwe::<Vec<u64>>::zero(glwe_len);
+        fourier_glwe.write_torus_form(&mut result, &fft);
+
+        assert_eq!(
+            coeff,
+            result.as_ref(),
+            "GLWE u64 roundtrip failed for log_n={log_n}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GLEV roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_glev_u32() {
+    let log_n = 3;
+    let fft = FullComplex64FftTable::new(log_n).unwrap();
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+
+    let k = 1;
+    let level = 2;
+    let glwe_len = (k + 1) * poly_len; // 2 * 8 = 16
+    let glev_len = level * glwe_len; // 2 * 16 = 32
+    let fourier_glwe_len = (k + 1) * fourier_len;
+    let fourier_glev_len = level * fourier_glwe_len;
+
+    let coeff: Vec<u32> = (0..glev_len)
+        .map(|i| match i % 5 {
+            0 => 0u32,
+            1 => 1u32,
+            2 => (-1i32) as u32,
+            3 => 2u32,
+            _ => (-2i32) as u32,
+        })
+        .collect();
+    let glev = Glev::new(coeff.clone());
+
+    let mut fourier_glev = FourierGlevOwned::zero(fourier_glev_len);
+    glev.write_fourier_form(&mut fourier_glev, &fft);
+
+    let mut result = Glev::<Vec<u32>>::zero(glev_len);
+    fourier_glev.write_torus_form(&mut result, &fft);
+
+    assert_eq!(coeff, result.as_ref(), "GLEV u32 roundtrip failed");
+}
+
+// ---------------------------------------------------------------------------
+// GGSW roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_ggsw_u32() {
+    let log_n = 2;
+    let fft = FullComplex64FftTable::new(log_n).unwrap();
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+
+    let k = 1;
+    let level = 1;
+    let glwe_len = (k + 1) * poly_len; // 2 * 4 = 8
+    let glev_len = level * glwe_len; // 1 * 8 = 8
+    let ggsw_len = (k + 1) * glev_len; // 2 * 8 = 16
+    let fourier_glwe_len = (k + 1) * fourier_len;
+    let fourier_glev_len = level * fourier_glwe_len;
+    let fourier_ggsw_len = (k + 1) * fourier_glev_len;
+
+    let coeff: Vec<u32> = (0..ggsw_len)
+        .map(|i| match i % 5 {
+            0 => 0u32,
+            1 => 1u32,
+            2 => (-1i32) as u32,
+            3 => 2u32,
+            _ => (-2i32) as u32,
+        })
+        .collect();
+    let ggsw = Ggsw::new(coeff.clone());
+
+    let mut fourier_ggsw = FourierGgswOwned::zero(fourier_ggsw_len);
+    ggsw.write_fourier_form(&mut fourier_ggsw, &fft);
+
+    let mut result = Ggsw::<Vec<u32>>::zero(ggsw_len);
+    fourier_ggsw.write_torus_form(&mut result, &fft);
+
+    assert_eq!(coeff, result.as_ref(), "GGSW u32 roundtrip failed");
+}
+
+// ---------------------------------------------------------------------------
+// Shape boundary tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn glwe_shape_matches_fourier_shape() {
+    let log_n = 3;
+    let fft = FullComplex64FftTable::new(log_n).unwrap();
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+
+    for k in 1..=3 {
+        let glwe_len = (k + 1) * poly_len;
+        let fourier_glwe_len = (k + 1) * fourier_len;
+
+        let glwe = Glwe::<Vec<u32>>::zero(glwe_len);
+        let mut fourier = FourierGlweOwned::zero(fourier_glwe_len);
+        glwe.write_fourier_form(&mut fourier, &fft);
+
+        assert_eq!(fourier.byte_count(), fourier_glwe_len * 16);
+    }
+}
+
+#[test]
+fn zero_glwe_roundtrip() {
+    let log_n = 3;
+    let fft = FullComplex64FftTable::new(log_n).unwrap();
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+
+    let k = 2;
+    let glwe_len = (k + 1) * poly_len;
+    let fourier_glwe_len = (k + 1) * fourier_len;
+
+    let glwe = Glwe::<Vec<u32>>::zero(glwe_len);
+    let mut fourier = FourierGlweOwned::zero(fourier_glwe_len);
+    glwe.write_fourier_form(&mut fourier, &fft);
+
+    // After forward transform, Fourier should still be close to zero
+    // (all-zero input → all-zero Fourier output)
+    for &c in fourier.as_ref() {
+        assert!(
+            c.re.abs() < 1e-12 && c.im.abs() < 1e-12,
+            "zero input should produce zero Fourier output"
+        );
+    }
+
+    let mut result = Glwe::<Vec<u32>>::zero(glwe_len);
+    fourier.write_torus_form(&mut result, &fft);
+    for &v in result.as_ref() {
+        assert_eq!(v, 0u32, "zero roundtrip should be exact");
+    }
+}

--- a/crates/primus_lattice/tests/tfhe_external_product.rs
+++ b/crates/primus_lattice/tests/tfhe_external_product.rs
@@ -1,0 +1,196 @@
+use primus_decompose::primitive::ApproxSignedBasis;
+use primus_fft::{FftTable, FullComplex64FftTable};
+use primus_lattice::context::tfhe::TfheFftContext;
+use primus_lattice::ggsw::Ggsw;
+use primus_lattice::ggsw::fourier::FourierGgswOwned;
+use primus_lattice::glwe::Glwe;
+use primus_lattice::tfhe::external_product::external_product_to;
+
+// ---------------------------------------------------------------------------
+// Naive coefficient-domain external product (reference, u32 only)
+// ---------------------------------------------------------------------------
+
+/// Naive coefficient-domain external product for u32: decomposes each input
+/// component, multiplies by the coefficient GGSW key, and accumulates.
+fn naive_external_product_u32(
+    input: &Glwe<Vec<u32>>,
+    ggsw_coeff: &Ggsw<Vec<u32>>,
+    output: &mut Glwe<Vec<u32>>,
+    basis: &ApproxSignedBasis<u32>,
+    glwe_dimension: usize,
+    poly_len: usize,
+) {
+    let total_components = glwe_dimension + 1;
+    let level = basis.decompose_length();
+    let glwe_len = total_components * poly_len;
+    let glev_len = level * glwe_len;
+
+    output.set_zero();
+
+    let mut carries = vec![false; poly_len];
+    let mut decomposed = vec![0u32; poly_len];
+
+    for input_component in 0..total_components {
+        let coeff_offset = input_component * poly_len;
+        let coeff_poly = &input.as_ref()[coeff_offset..coeff_offset + poly_len];
+
+        basis.init_carry_slice(coeff_poly, &mut carries);
+
+        for (level_idx, decomposer) in basis.decompose_iter().enumerate() {
+            decomposer.decompose_slice_to(coeff_poly, &mut decomposed, &mut carries);
+
+            for output_component in 0..total_components {
+                let out_offset = output_component * poly_len;
+                let out_poly = &mut output.as_mut()[out_offset..out_offset + poly_len];
+
+                let key_offset =
+                    input_component * glev_len + level_idx * glwe_len + output_component * poly_len;
+                let key_poly = &ggsw_coeff.as_ref()[key_offset..key_offset + poly_len];
+
+                for j in 0..poly_len {
+                    // Interpret each torus value as centered i32, do arithmetic in i64
+                    let s = decomposed[j] as i32 as i64;
+                    let g = key_poly[j] as i32 as i64;
+                    let prod = s.wrapping_mul(g);
+                    let old = out_poly[j] as i32 as i64;
+                    let sum = old.wrapping_add(prod);
+                    out_poly[j] = (sum as i32) as u32;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn external_product_smoke_test() {
+    let log_n = 3;
+    let fft = FullComplex64FftTable::new(log_n).unwrap();
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+
+    // Parameters: k=1, level=2
+    let glwe_dimension = 1; // mask count k
+    let total_components = glwe_dimension + 1; // k + 1 = 2
+    let level = 2;
+
+    let glwe_len = total_components * poly_len; // 2 * 8 = 16
+    let glev_len = level * glwe_len; // 2 * 16 = 32
+    let ggsw_len = total_components * glev_len; // 2 * 32 = 64
+
+    // Create basis: modulus=None (power-of-2), log_basis=4 (B=16)
+    let basis = ApproxSignedBasis::<u32>::new(None, 4, Some(level));
+
+    // Create coefficient GGSW key with small values
+    let ggsw_coeff: Vec<u32> = (0..ggsw_len).map(|i| ((i % 7) as i32 - 3) as u32).collect();
+    let ggsw_coeff = Ggsw::new(ggsw_coeff);
+
+    // Convert to Fourier
+    let fourier_glwe_len = total_components * fourier_len; // 2 * 8 = 16
+    let fourier_glev_len = level * fourier_glwe_len; // 2 * 16 = 32
+    let fourier_ggsw_len = total_components * fourier_glev_len; // 2 * 32 = 64
+    let mut fourier_key = FourierGgswOwned::zero(fourier_ggsw_len);
+    ggsw_coeff.write_fourier_form(&mut fourier_key, &fft);
+
+    // Create input GLWE
+    let input: Vec<u32> = (0..glwe_len).map(|i| ((i as i32 % 5) - 2) as u32).collect();
+    let input_glwe = Glwe::new(input);
+
+    // External product (FFT-based)
+    let mut ctx = TfheFftContext::<u32>::new(poly_len, fourier_len, glwe_dimension);
+    let mut output_fft = Glwe::<Vec<u32>>::zero(glwe_len);
+    external_product_to(
+        &input_glwe,
+        &fourier_key,
+        &mut output_fft,
+        &basis,
+        &fft,
+        &mut ctx,
+        glwe_dimension,
+    );
+
+    // Naive coefficient-domain reference
+    let mut output_naive = Glwe::<Vec<u32>>::zero(glwe_len);
+    naive_external_product_u32(
+        &input_glwe,
+        &ggsw_coeff,
+        &mut output_naive,
+        &basis,
+        glwe_dimension,
+        poly_len,
+    );
+
+    assert_eq!(
+        output_fft.as_ref(),
+        output_naive.as_ref(),
+        "FFT-based external product must match naive coefficient reference"
+    );
+}
+
+#[test]
+fn external_product_zero_input() {
+    let log_n = 2;
+    let fft = FullComplex64FftTable::new(log_n).unwrap();
+    let poly_len = fft.poly_length();
+    let fourier_len = fft.fourier_length();
+    let glwe_dimension = 1; // mask count k = 1
+    let total_components = glwe_dimension + 1; // = 2
+    let level = 1;
+    let glwe_len = total_components * poly_len;
+    let fourier_glwe_len = total_components * fourier_len;
+    let fourier_glev_len = level * fourier_glwe_len;
+    let fourier_ggsw_len = total_components * fourier_glev_len;
+
+    let basis = ApproxSignedBasis::<u32>::new(None, 8, Some(level));
+
+    // Arbitrary Fourier key
+    let mut key = FourierGgswOwned::zero(fourier_ggsw_len);
+    key.as_mut()
+        .fill_with(|| num_complex::Complex64::new(1.0, 0.0));
+
+    let input = Glwe::<Vec<u32>>::zero(glwe_len);
+    let mut output = Glwe::<Vec<u32>>::zero(glwe_len);
+    let mut ctx = TfheFftContext::<u32>::new(poly_len, fourier_len, glwe_dimension);
+
+    external_product_to(
+        &input,
+        &key,
+        &mut output,
+        &basis,
+        &fft,
+        &mut ctx,
+        glwe_dimension,
+    );
+
+    // Zero input should produce zero output (all zero coefficients → all zero decomposed digits)
+    for &v in output.as_ref() {
+        assert_eq!(v, 0u32);
+    }
+}
+
+#[test]
+fn context_sizes() {
+    let poly_len = 1024;
+    let fourier_len = 1024;
+    let glwe_dimension = 2; // k = 2, total = 3
+
+    let ctx = TfheFftContext::<u32>::new(poly_len, fourier_len, glwe_dimension);
+    assert_eq!(ctx.carries.len(), poly_len);
+    assert_eq!(ctx.decomposed_poly.len(), poly_len);
+    assert_eq!(ctx.decomposed_fourier.len(), fourier_len);
+    // k + 1 = 3
+    assert_eq!(
+        ctx.fourier_accumulator.len(),
+        (glwe_dimension + 1) * fourier_len
+    );
+
+    let mut ctx = ctx;
+    ctx.resize(512, 256, 3); // k=3, total=4
+    assert_eq!(ctx.carries.len(), 512);
+    assert_eq!(ctx.decomposed_poly.len(), 512);
+    assert_eq!(ctx.decomposed_fourier.len(), 256);
+    assert_eq!(ctx.fourier_accumulator.len(), (3 + 1) * 256);
+}

--- a/crates/primus_ntt/src/ntt/prime32/tests.rs
+++ b/crates/primus_ntt/src/ntt/prime32/tests.rs
@@ -254,7 +254,7 @@ fn test_builder_lane_order() {
         "avx2 forward roots should be non-empty for n=64"
     );
     assert!(
-        avx2_fwd.len() % 8 == 0,
+        avx2_fwd.len().is_multiple_of(8),
         "avx2 output must be multiple of 8 u32s"
     );
 
@@ -312,7 +312,7 @@ fn test_builder_lane_order() {
     let avx512_fwd =
         crate::ntt::prime32::avx512::precompute::build_avx512_roots_u32(n, &roots, false);
     assert!(!avx512_fwd.is_empty());
-    assert!(avx512_fwd.len() % 16 == 0);
+    assert!(avx512_fwd.len().is_multiple_of(16));
     assert_eq!(avx512_fwd[0], roots[4]);
     assert_eq!(avx512_fwd[8], roots[5]);
 

--- a/crates/primus_poly/Cargo.toml
+++ b/crates/primus_poly/Cargo.toml
@@ -12,6 +12,7 @@ primus_modulus = { path = "../primus_modulus" }
 primus_factor = { path = "../primus_factor" }
 primus_distr = { path = "../primus_distr" }
 
+num-complex = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
 itertools = { workspace = true }

--- a/crates/primus_poly/src/fourier/add.rs
+++ b/crates/primus_poly/src/fourier/add.rs
@@ -9,6 +9,7 @@ where
 {
     /// Performs `self + rhs` (pointwise complex addition).
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn add<A>(mut self, rhs: &FourierPolynomial<A>) -> Self
     where
         A: RawData<Elem = Complex64> + Data,

--- a/crates/primus_poly/src/fourier/add.rs
+++ b/crates/primus_poly/src/fourier/add.rs
@@ -1,0 +1,88 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, RawData};
+
+use super::FourierPolynomial;
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataMut,
+{
+    /// Performs `self + rhs` (pointwise complex addition).
+    #[inline]
+    pub fn add<A>(mut self, rhs: &FourierPolynomial<A>) -> Self
+    where
+        A: RawData<Elem = Complex64> + Data,
+    {
+        self.add_assign(rhs);
+        self
+    }
+
+    /// Performs `self += rhs` (pointwise complex addition in place).
+    #[inline]
+    pub fn add_assign<A>(&mut self, rhs: &FourierPolynomial<A>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        for (a, &b) in self.iter_mut().zip(rhs.iter()) {
+            *a += b;
+        }
+    }
+}
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Performs `output = self + rhs` (pointwise complex addition).
+    #[inline]
+    pub fn add_to<A, B>(&self, rhs: &FourierPolynomial<A>, output: &mut FourierPolynomial<B>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+        B: RawData<Elem = Complex64> + DataMut,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        debug_assert_eq!(self.fourier_length(), output.fourier_length());
+        for ((&a, &b), out) in self.iter().zip(rhs.iter()).zip(output.iter_mut()) {
+            *out = a + b;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fourier::FourierPolynomialOwned;
+
+    #[test]
+    fn test_add_assign() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 1.0),
+        ]);
+        let b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(3.0, 0.0),
+            Complex64::new(0.0, 1.0),
+        ]);
+        let mut result = a;
+        result.add_assign(&b);
+        assert_eq!(result.as_slice()[0], Complex64::new(4.0, 0.0));
+        assert_eq!(result.as_slice()[1], Complex64::new(2.0, 2.0));
+    }
+
+    #[test]
+    fn test_add_to() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+        ]);
+        let b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 1.0),
+        ]);
+        let mut output = FourierPolynomialOwned::zero(2);
+        a.add_to(&b, &mut output);
+        assert_eq!(output.as_slice()[0], Complex64::new(1.0, 0.0));
+        assert_eq!(output.as_slice()[1], Complex64::new(0.0, 1.0));
+    }
+}

--- a/crates/primus_poly/src/fourier/mod.rs
+++ b/crates/primus_poly/src/fourier/mod.rs
@@ -1,0 +1,468 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, DataOwned, RawData};
+
+mod add;
+mod mul;
+mod neg;
+mod sub;
+
+/// Owned [`FourierPolynomial`] backed by a [`Vec`].
+pub type FourierPolynomialOwned = FourierPolynomial<Vec<Complex64>>;
+/// Borrowed [`FourierPolynomial`] backed by an immutable slice.
+pub type FourierPolynomialRef<'a> = FourierPolynomial<&'a [Complex64]>;
+/// Mutably borrowed [`FourierPolynomial`] backed by a mutable slice.
+pub type FourierPolynomialMut<'a> = FourierPolynomial<&'a mut [Complex64]>;
+
+/// A container for interleaved complex Fourier-domain values.
+///
+/// Represents one negacyclic FFT component in the Fourier domain under
+/// `Z[X] / (X^N + 1)`. Unlike coefficient [`Polynomial`](crate::Polynomial),
+/// this type does not carry a modulus or support modular arithmetic —
+/// Fourier operations are approximate floating-point arithmetic.
+///
+/// # Element type
+///
+/// Uses [`Complex64`] (interleaved double-precision complex numbers).
+/// Pointwise arithmetic kernels live in
+/// [`primus_fft::complex64::arithmetic`].
+///
+/// # Storage polymorphism
+///
+/// `S` abstracts over the memory backend. Common aliases:
+/// - [`FourierPolynomialOwned`] — owned `Vec<Complex64>`
+/// - [`FourierPolynomialRef`] — borrowed `&[Complex64]`
+/// - [`FourierPolynomialMut`] — mutably borrowed `&mut [Complex64]`
+#[derive(Debug, Clone, PartialEq)]
+pub struct FourierPolynomial<S>(pub S)
+where
+    S: RawData<Elem = Complex64>;
+
+// ---------------------------------------------------------------------------
+// Iterators (manual — impl_iters! requires T: FheUint)
+// ---------------------------------------------------------------------------
+
+/// Immutable chunked iterator over [`FourierPolynomial`] components.
+#[derive(Debug, Clone)]
+pub struct FourierPolynomialIter<'a> {
+    /// The underlying chunked iterator.
+    pub iter: core::slice::ChunksExact<'a, Complex64>,
+}
+
+impl<'a> FourierPolynomialIter<'a> {
+    /// Creates a new iterator that yields `FourierPolynomialRef` chunks
+    /// of `fourier_len` elements each.
+    #[inline]
+    pub fn new(data: &'a [Complex64], fourier_len: usize) -> Self {
+        Self {
+            iter: data.chunks_exact(fourier_len),
+        }
+    }
+}
+
+impl<'a> Iterator for FourierPolynomialIter<'a> {
+    type Item = FourierPolynomial<&'a [Complex64]>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(FourierPolynomial)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(FourierPolynomial)
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
+    }
+}
+
+impl<'a> core::iter::FusedIterator for FourierPolynomialIter<'a> {}
+impl<'a> core::iter::DoubleEndedIterator for FourierPolynomialIter<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(FourierPolynomial)
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n).map(FourierPolynomial)
+    }
+}
+impl<'a> core::iter::ExactSizeIterator for FourierPolynomialIter<'a> {}
+
+/// Mutable chunked iterator over [`FourierPolynomial`] components.
+#[derive(Debug)]
+pub struct FourierPolynomialIterMut<'a> {
+    /// The underlying mutable chunked iterator.
+    pub iter: core::slice::ChunksExactMut<'a, Complex64>,
+}
+
+impl<'a> FourierPolynomialIterMut<'a> {
+    /// Creates a new mutable iterator that yields `FourierPolynomialMut` chunks
+    /// of `fourier_len` elements each.
+    #[inline]
+    pub fn new(data: &'a mut [Complex64], fourier_len: usize) -> Self {
+        Self {
+            iter: data.chunks_exact_mut(fourier_len),
+        }
+    }
+}
+
+impl<'a> Iterator for FourierPolynomialIterMut<'a> {
+    type Item = FourierPolynomial<&'a mut [Complex64]>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(FourierPolynomial)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(FourierPolynomial)
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
+    }
+}
+
+impl<'a> core::iter::FusedIterator for FourierPolynomialIterMut<'a> {}
+impl<'a> core::iter::DoubleEndedIterator for FourierPolynomialIterMut<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(FourierPolynomial)
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n).map(FourierPolynomial)
+    }
+}
+impl<'a> core::iter::ExactSizeIterator for FourierPolynomialIterMut<'a> {}
+
+// ---------------------------------------------------------------------------
+// Methods: RawData<Elem = Complex64>
+// ---------------------------------------------------------------------------
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64>,
+{
+    /// Creates a new [`FourierPolynomial`].
+    #[inline]
+    pub fn new(values: S) -> Self {
+        Self(values)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Methods: DataOwned
+// ---------------------------------------------------------------------------
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataOwned,
+{
+    /// Creates a [`FourierPolynomial`] with all elements set to zero.
+    #[inline]
+    pub fn zero(fourier_length: usize) -> Self {
+        Self(S::from_vec(vec![Complex64::new(0.0, 0.0); fourier_length]))
+    }
+
+    /// Consumes `self`, returning the underlying storage.
+    #[inline]
+    pub fn into_owned(self) -> S {
+        self.0
+    }
+
+    /// Constructs a new Fourier polynomial by cloning elements from a slice.
+    #[inline]
+    pub fn from_slice(data: &[Complex64]) -> Self {
+        Self::new(S::from_slice(data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Methods: DataMut
+// ---------------------------------------------------------------------------
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataMut,
+{
+    /// Extracts a mutable slice of all elements.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [Complex64] {
+        self.0.as_mut_slice()
+    }
+
+    /// Returns a mutable iterator over the elements.
+    #[inline]
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, Complex64> {
+        self.0.iter_mut()
+    }
+
+    /// Copies elements from `src` into `self`. Lengths must match.
+    #[inline]
+    pub fn copy_from(&mut self, src: impl AsRef<[Complex64]>) {
+        self.0.copy_from_slice(src.as_ref());
+    }
+
+    /// Sets all elements to zero.
+    #[inline]
+    pub fn set_zero(&mut self) {
+        self.0.fill(Complex64::new(0.0, 0.0));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Methods: Data (read-only)
+// ---------------------------------------------------------------------------
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Extracts a slice containing all elements.
+    #[inline]
+    pub fn as_slice(&self) -> &[Complex64] {
+        self.0.as_slice()
+    }
+
+    /// Returns the Fourier length (number of complex frequency values).
+    #[inline]
+    pub fn fourier_length(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns a read-only iterator over the elements.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, Complex64> {
+        self.0.iter()
+    }
+
+    /// Returns `true` if all elements are zero.
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        let zero = Complex64::new(0.0, 0.0);
+        self.0.iter().all(|&x| x == zero)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience trait impls
+// ---------------------------------------------------------------------------
+
+impl<S> AsRef<[Complex64]> for FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    #[inline]
+    fn as_ref(&self) -> &[Complex64] {
+        self.as_slice()
+    }
+}
+
+impl<S> AsMut<[Complex64]> for FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataMut,
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut [Complex64] {
+        self.as_mut_slice()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_and_as_slice() {
+        let data = vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 1.0),
+            Complex64::new(2.0, 3.0),
+        ];
+        let poly = FourierPolynomial::new(data.clone());
+        assert_eq!(poly.as_slice(), data.as_slice());
+        assert_eq!(poly.fourier_length(), 3);
+    }
+
+    #[test]
+    fn test_zero() {
+        let poly = FourierPolynomialOwned::zero(4);
+        assert_eq!(poly.fourier_length(), 4);
+        assert!(poly.is_zero());
+    }
+
+    #[test]
+    fn test_set_zero() {
+        let data = vec![Complex64::new(1.0, 2.0); 4];
+        let mut poly = FourierPolynomial::new(data);
+        assert!(!poly.is_zero());
+        poly.set_zero();
+        assert!(poly.is_zero());
+    }
+
+    #[test]
+    fn test_copy_from() {
+        let src = vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)];
+        let mut poly = FourierPolynomialOwned::zero(2);
+        poly.copy_from(&src);
+        assert_eq!(poly.as_slice(), src.as_slice());
+    }
+
+    #[test]
+    fn test_from_slice() {
+        let data = vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+        ];
+        let poly = FourierPolynomialOwned::from_slice(&data);
+        assert_eq!(poly.as_slice(), data.as_slice());
+    }
+
+    #[test]
+    fn test_into_owned() {
+        let data = vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)];
+        let poly = FourierPolynomialOwned::from_slice(&data);
+        let vec: Vec<Complex64> = poly.into_owned();
+        assert_eq!(vec, data);
+    }
+
+    #[test]
+    fn test_iter() {
+        let data = vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)];
+        let poly = FourierPolynomial::new(data.clone());
+        let collected: Vec<Complex64> = poly.iter().copied().collect();
+        assert_eq!(collected, data);
+    }
+
+    #[test]
+    fn test_iter_mut() {
+        let data = vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)];
+        let mut poly = FourierPolynomial::new(data.clone());
+        for x in poly.iter_mut() {
+            *x = Complex64::new(x.re + 1.0, 0.0);
+        }
+        assert_eq!(poly.as_slice()[0], Complex64::new(2.0, 0.0));
+        assert_eq!(poly.as_slice()[1], Complex64::new(3.0, 0.0));
+    }
+
+    #[test]
+    fn test_fourier_iterator_chunks() {
+        // Flat storage: 2 Fourier polynomials, each of length 3
+        let data = vec![
+            // poly 0
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            // poly 1
+            Complex64::new(4.0, 0.0),
+            Complex64::new(5.0, 0.0),
+            Complex64::new(6.0, 0.0),
+        ];
+        let iter = FourierPolynomialIter::new(&data, 3);
+        let polys: Vec<_> = iter.collect();
+        assert_eq!(polys.len(), 2);
+        assert_eq!(
+            polys[0].as_slice(),
+            &[
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(3.0, 0.0),
+            ]
+        );
+        assert_eq!(
+            polys[1].as_slice(),
+            &[
+                Complex64::new(4.0, 0.0),
+                Complex64::new(5.0, 0.0),
+                Complex64::new(6.0, 0.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_fourier_iterator_mut_chunks() {
+        let mut data = vec![Complex64::new(0.0, 0.0); 6];
+        let iter = FourierPolynomialIterMut::new(&mut data, 3);
+        for mut poly in iter {
+            poly.set_zero();
+        }
+        assert!(data.iter().all(|&x| x == Complex64::new(0.0, 0.0)));
+    }
+
+    #[test]
+    fn test_fourier_iterator_empty() {
+        let data: Vec<Complex64> = vec![];
+        let iter = FourierPolynomialIter::new(&data, 3);
+        assert_eq!(iter.count(), 0);
+    }
+
+    #[test]
+    fn test_fourier_iterator_trailing_remainder() {
+        // 5 elements with chunk size 3: only 1 full chunk, 2 remainder elements dropped
+        let data = vec![Complex64::new(0.0, 0.0); 5];
+        let iter = FourierPolynomialIter::new(&data, 3);
+        assert_eq!(iter.count(), 1); // trailing 2 elements omitted by chunks_exact
+    }
+
+    #[test]
+    fn test_fourier_polynomial_borrowed() {
+        let data = vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)];
+        // FourierPolynomialRef via new() on a slice reference
+        let poly_ref = FourierPolynomial::new(data.as_slice());
+        assert_eq!(poly_ref.fourier_length(), 2);
+        assert_eq!(poly_ref.as_slice(), data.as_slice());
+    }
+
+    #[test]
+    fn test_is_zero() {
+        let poly = FourierPolynomialOwned::zero(4);
+        assert!(poly.is_zero());
+
+        let poly2 =
+            FourierPolynomial::new(vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)]);
+        assert!(!poly2.is_zero());
+    }
+
+    #[test]
+    fn test_as_ref_and_as_mut() {
+        let mut poly = FourierPolynomialOwned::zero(2);
+        // AsMut
+        poly.as_mut()[0] = Complex64::new(1.0, 1.0);
+        // AsRef
+        assert_eq!(poly.as_ref()[0], Complex64::new(1.0, 1.0));
+        assert_eq!(poly.as_ref()[1], Complex64::new(0.0, 0.0));
+    }
+}

--- a/crates/primus_poly/src/fourier/mod.rs
+++ b/crates/primus_poly/src/fourier/mod.rs
@@ -24,7 +24,7 @@ pub type FourierPolynomialMut<'a> = FourierPolynomial<&'a mut [Complex64]>;
 ///
 /// Uses [`Complex64`] (interleaved double-precision complex numbers).
 /// Pointwise arithmetic kernels live in
-/// [`primus_fft::complex64::arithmetic`].
+/// `primus_fft::complex64::arithmetic`.
 ///
 /// # Storage polymorphism
 ///

--- a/crates/primus_poly/src/fourier/mul.rs
+++ b/crates/primus_poly/src/fourier/mul.rs
@@ -9,6 +9,7 @@ where
 {
     /// Performs `self * rhs` (pointwise complex multiplication).
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn mul<A>(mut self, rhs: &FourierPolynomial<A>) -> Self
     where
         A: RawData<Elem = Complex64> + Data,

--- a/crates/primus_poly/src/fourier/mul.rs
+++ b/crates/primus_poly/src/fourier/mul.rs
@@ -1,0 +1,127 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, RawData};
+
+use super::FourierPolynomial;
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataMut,
+{
+    /// Performs `self * rhs` (pointwise complex multiplication).
+    #[inline]
+    pub fn mul<A>(mut self, rhs: &FourierPolynomial<A>) -> Self
+    where
+        A: RawData<Elem = Complex64> + Data,
+    {
+        self.mul_assign(rhs);
+        self
+    }
+
+    /// Performs `self *= rhs` (pointwise complex multiplication in place).
+    #[inline]
+    pub fn mul_assign<A>(&mut self, rhs: &FourierPolynomial<A>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        for (a, &b) in self.iter_mut().zip(rhs.iter()) {
+            *a *= b;
+        }
+    }
+
+    /// Performs `self += lhs * rhs` (fused multiply-add) in place.
+    ///
+    /// This is the hot-path accumulation used in TFHE external product and
+    /// CMUX operations.
+    #[inline]
+    pub fn add_mul_assign<A, B>(&mut self, lhs: &FourierPolynomial<A>, rhs: &FourierPolynomial<B>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+        B: RawData<Elem = Complex64> + Data,
+    {
+        debug_assert_eq!(self.fourier_length(), lhs.fourier_length());
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        for ((acc, &l), &r) in self.iter_mut().zip(lhs.iter()).zip(rhs.iter()) {
+            *acc += l * r;
+        }
+    }
+}
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Performs `output = self * rhs` (pointwise complex multiplication).
+    #[inline]
+    pub fn mul_to<A, B>(&self, rhs: &FourierPolynomial<A>, output: &mut FourierPolynomial<B>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+        B: RawData<Elem = Complex64> + DataMut,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        debug_assert_eq!(self.fourier_length(), output.fourier_length());
+        for ((&a, &b), out) in self.iter().zip(rhs.iter()).zip(output.iter_mut()) {
+            *out = a * b;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fourier::FourierPolynomialOwned;
+
+    #[test]
+    fn test_mul_assign() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 1.0),
+        ]);
+        let b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(3.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]);
+        let mut result = a;
+        result.mul_assign(&b);
+        assert_eq!(result.as_slice()[0], Complex64::new(6.0, 0.0));
+        // (i) * 1 = i
+        assert_eq!(result.as_slice()[1], Complex64::new(0.0, 1.0));
+    }
+
+    #[test]
+    fn test_add_mul_assign() {
+        // acc starts as [1, 1], lhs = [2, i], rhs = [3, 1]
+        // acc += lhs * rhs => [1+2*3, 1+i*1] = [7, 1+i]
+        let mut acc = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]);
+        let lhs = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 1.0),
+        ]);
+        let rhs = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(3.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]);
+        acc.add_mul_assign(&lhs, &rhs);
+        assert_eq!(acc.as_slice()[0], Complex64::new(7.0, 0.0));
+        assert_eq!(acc.as_slice()[1], Complex64::new(1.0, 1.0));
+    }
+
+    #[test]
+    fn test_mul_to() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 1.0),
+        ]);
+        let b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(3.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]);
+        let mut output = FourierPolynomialOwned::zero(2);
+        a.mul_to(&b, &mut output);
+        assert_eq!(output.as_slice()[0], Complex64::new(6.0, 0.0));
+        assert_eq!(output.as_slice()[1], Complex64::new(0.0, 1.0));
+    }
+}

--- a/crates/primus_poly/src/fourier/neg.rs
+++ b/crates/primus_poly/src/fourier/neg.rs
@@ -1,0 +1,70 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, RawData};
+
+use super::FourierPolynomial;
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataMut,
+{
+    /// Performs the unary `-` operation (pointwise complex negation).
+    #[inline]
+    pub fn neg(mut self) -> Self {
+        self.neg_assign();
+        self
+    }
+
+    /// Performs the unary `-` operation in place.
+    #[inline]
+    pub fn neg_assign(&mut self) {
+        for a in self.iter_mut() {
+            *a = -*a;
+        }
+    }
+}
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Performs `output = -self` (pointwise complex negation).
+    #[inline]
+    pub fn neg_to<A>(&self, output: &mut FourierPolynomial<A>)
+    where
+        A: RawData<Elem = Complex64> + DataMut,
+    {
+        debug_assert_eq!(self.fourier_length(), output.fourier_length());
+        for (&a, out) in self.iter().zip(output.iter_mut()) {
+            *out = -a;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fourier::FourierPolynomialOwned;
+
+    #[test]
+    fn test_neg_assign() {
+        let mut a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(1.0, 2.0),
+            Complex64::new(-3.0, 0.0),
+        ]);
+        a.neg_assign();
+        assert_eq!(a.as_slice()[0], Complex64::new(-1.0, -2.0));
+        assert_eq!(a.as_slice()[1], Complex64::new(3.0, 0.0));
+    }
+
+    #[test]
+    fn test_neg_to() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(1.0, -1.0),
+            Complex64::new(0.0, 2.0),
+        ]);
+        let mut output = FourierPolynomialOwned::zero(2);
+        a.neg_to(&mut output);
+        assert_eq!(output.as_slice()[0], Complex64::new(-1.0, 1.0));
+        assert_eq!(output.as_slice()[1], Complex64::new(0.0, -2.0));
+    }
+}

--- a/crates/primus_poly/src/fourier/neg.rs
+++ b/crates/primus_poly/src/fourier/neg.rs
@@ -9,6 +9,7 @@ where
 {
     /// Performs the unary `-` operation (pointwise complex negation).
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn neg(mut self) -> Self {
         self.neg_assign();
         self

--- a/crates/primus_poly/src/fourier/sub.rs
+++ b/crates/primus_poly/src/fourier/sub.rs
@@ -1,0 +1,116 @@
+use num_complex::Complex64;
+use primus_data::{Data, DataMut, RawData};
+
+use super::FourierPolynomial;
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + DataMut,
+{
+    /// Performs `self - rhs` (pointwise complex subtraction).
+    #[inline]
+    pub fn sub<A>(mut self, rhs: &FourierPolynomial<A>) -> Self
+    where
+        A: RawData<Elem = Complex64> + Data,
+    {
+        self.sub_assign(rhs);
+        self
+    }
+
+    /// Performs `self -= rhs` (pointwise complex subtraction in place).
+    #[inline]
+    pub fn sub_assign<A>(&mut self, rhs: &FourierPolynomial<A>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        for (a, &b) in self.iter_mut().zip(rhs.iter()) {
+            *a -= b;
+        }
+    }
+}
+
+impl<S> FourierPolynomial<S>
+where
+    S: RawData<Elem = Complex64> + Data,
+{
+    /// Performs `rhs = self - rhs` (reverse subtraction in place).
+    #[inline]
+    pub fn sub_rev_assign<A>(&self, rhs: &mut FourierPolynomial<A>)
+    where
+        A: RawData<Elem = Complex64> + DataMut,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        for (b, &a) in rhs.iter_mut().zip(self.iter()) {
+            *b = a - *b;
+        }
+    }
+
+    /// Performs `output = self - rhs` (pointwise complex subtraction).
+    #[inline]
+    pub fn sub_to<A, B>(&self, rhs: &FourierPolynomial<A>, output: &mut FourierPolynomial<B>)
+    where
+        A: RawData<Elem = Complex64> + Data,
+        B: RawData<Elem = Complex64> + DataMut,
+    {
+        debug_assert_eq!(self.fourier_length(), rhs.fourier_length());
+        debug_assert_eq!(self.fourier_length(), output.fourier_length());
+        for ((&a, &b), out) in self.iter().zip(rhs.iter()).zip(output.iter_mut()) {
+            *out = a - b;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fourier::FourierPolynomialOwned;
+
+    #[test]
+    fn test_sub_assign() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(5.0, 2.0),
+            Complex64::new(3.0, 1.0),
+        ]);
+        let b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(2.0, 0.0),
+            Complex64::new(1.0, 1.0),
+        ]);
+        let mut result = a;
+        result.sub_assign(&b);
+        assert_eq!(result.as_slice()[0], Complex64::new(3.0, 2.0));
+        assert_eq!(result.as_slice()[1], Complex64::new(2.0, 0.0));
+    }
+
+    #[test]
+    fn test_sub_rev_assign() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(5.0, 0.0),
+            Complex64::new(3.0, 0.0),
+        ]);
+        let mut b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(2.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]);
+        a.sub_rev_assign(&mut b);
+        // b = a - b: [5-2, 3-1] = [3, 2]
+        assert_eq!(b.as_slice()[0], Complex64::new(3.0, 0.0));
+        assert_eq!(b.as_slice()[1], Complex64::new(2.0, 0.0));
+    }
+
+    #[test]
+    fn test_sub_to() {
+        let a = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(5.0, 0.0),
+            Complex64::new(3.0, 0.0),
+        ]);
+        let b = FourierPolynomialOwned::from_slice(&[
+            Complex64::new(2.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]);
+        let mut output = FourierPolynomialOwned::zero(2);
+        a.sub_to(&b, &mut output);
+        assert_eq!(output.as_slice()[0], Complex64::new(3.0, 0.0));
+        assert_eq!(output.as_slice()[1], Complex64::new(2.0, 0.0));
+    }
+}

--- a/crates/primus_poly/src/fourier/sub.rs
+++ b/crates/primus_poly/src/fourier/sub.rs
@@ -9,6 +9,7 @@ where
 {
     /// Performs `self - rhs` (pointwise complex subtraction).
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn sub<A>(mut self, rhs: &FourierPolynomial<A>) -> Self
     where
         A: RawData<Elem = Complex64> + Data,

--- a/crates/primus_poly/src/lib.rs
+++ b/crates/primus_poly/src/lib.rs
@@ -7,6 +7,7 @@
 //! - [`BigUintPolynomial`]: polynomial with big integer coefficients.
 //! - [`CrtPolynomial`]: polynomial under Chinese Remainder Theorem decomposition.
 //! - [`DcrtPolynomial`]: double-CRT polynomial (CRT + NTT).
+//! - [`FourierPolynomial`]: polynomial in the Fourier domain (complex values).
 
 #![deny(missing_docs)]
 
@@ -18,6 +19,7 @@ mod array;
 mod big_uint_poly;
 mod crt;
 mod dcrt;
+mod fourier;
 mod ntt;
 mod poly;
 
@@ -27,6 +29,11 @@ pub use big_uint_poly::{BigUintPolynomial, BigUintPolynomialIter, BigUintPolynom
 
 pub use crt::{CrtPolynomial, CrtPolynomialIter, CrtPolynomialIterMut};
 pub use dcrt::{DcrtPolynomial, DcrtPolynomialIter, DcrtPolynomialIterMut};
+
+pub use fourier::{
+    FourierPolynomial, FourierPolynomialIter, FourierPolynomialIterMut, FourierPolynomialMut,
+    FourierPolynomialOwned, FourierPolynomialRef,
+};
 
 pub use ntt::{
     NttPolynomial, NttPolynomialIter, NttPolynomialIterMut, NttPolynomialMut, NttPolynomialOwned,


### PR DESCRIPTION
## `primus_fft`

Torus negacyclic FFT transforms for `Z[X]/(X^N+1)`, the polynomial ring used by TFHE. Exports the `FftTable` trait (forward/inverse torus-FFT), a `FullComplex64FftTable` reference backend built on `rustfft` that implements negacyclic convolution via twist-FFT (pre-multiply by `exp(πi·j/N)`, standard FFT, untwist with `conj(ψ^j)/N`), the `TorusFftValue` trait for converting between centered `f64` and torus integers (`u16`/`u32`/`u64`), and pointwise `Complex64` arithmetic kernels for the TFHE hot path.

## `primus_lattice`

Lattice ciphertext containers for FHE, organized by cryptographic problem:

- **LWE**: `Lwe<S>`, `MultiMsgLwe<S>`
- **GLWE**: `Glwe`, `NttGlwe`, `CrtGlwe`, `DcrtGlwe`, `BigUintGlwe`, **`FourierGlwe`**
- **GLev** (gadget-decomposed GLWE): same 5 variants + **`FourierGlev`**
- **GGSW** (matrix of GLev): same 5 variants + **`FourierGgsw`**
- **RLWE / RLev / RGSW**: ring variants (`Rlwe`, `NttRlwe`, `CrtRlwe`, `DcrtRlwe`, `TruncatedRlwe`, etc.)
- **NTRU**: `Ntru<S>`, `NttNtru<S>`

Every type is a newtype over `S: RawData` with `new`, `zero`, `set_zero`, `byte_count`, sub-structure chunked iterators, element-wise arithmetic, and domain conversions (`into_ntt_form`/`write_coeff_form`). The **Fourier variants** store `Complex64` interleaved values. A **`tfhe` module** adds torus-semantic aliases (`TorusLwe`/`TorusGlwe`/`TorusGlev`/`TorusGgsw`), coefficient↔Fourier conversion, and the **external product** — the core TFHE bootstrapping operation — with pre-allocated scratch buffers (`TfheFftContext`) for zero-allocation execution.